### PR TITLE
Rlvrelay

### DIFF
--- a/lsl/OpenCollar - rlvrelay - Help
+++ b/lsl/OpenCollar - rlvrelay - Help
@@ -100,6 +100,10 @@ In the request dialog, which will pop up in Ask mode when an RLV source tries to
 
 * [initials]relay minmode [playful/land/safeword] [on/off] (owner only): sets the minimal submodes.
 
+* [initials]relay getdebug: starts relay debugging, i.e. forwards all relay chat to the person issuing this command
+
+* [initials]relay stopdebug: stops relay debugging
+
 
 2. Technical information for RLV scripters
 

--- a/lsl/OpenCollar - rlvrelay.lsl
+++ b/lsl/OpenCollar - rlvrelay.lsl
@@ -103,8 +103,7 @@ integer g_iSafeMode = 1;
 integer g_iLandMode = 1;
 integer g_iPlayMode = 0;
 
-
-//list g_lBaseModes = ["off", "restricted", "ask", "auto"];
+key g_kDebugRcpt = NULL_KEY; // recipient key for relay chat debugging (useful since you cannot eavesdrop llRegionSayTo)
 
 
 
@@ -333,14 +332,16 @@ string HandleCommand(string sIdent, key kID, string sCom, integer iAuthed)
             //better try to execute the rest of the command, right?
             sAck=""; //not ko'ing as some old bug in chorazin cages would make them go wrong. Otherwise "ko" looks closer in spirit to the relay spec. (issue 514)
         }//probably an ill-formed command, not answering
-        if (sAck) llShout(RELAY_CHANNEL,sIdent+","+(string)kID+","+sCom+","+sAck);
+        if (sAck) sendrlvr(sIdent, kID, sCom, sAck);
     }
     return "";
 }
 
-Debug(string sMsg)
+sendrlvr(string sIdent, key kID, string sCom, string sAck)
 {
-    llInstantMessage(g_kWearer,sMsg);
+    llRegionSayTo(kID, RELAY_CHANNEL, sIdent+","+(string)kID+","+sCom+","+sAck);
+    if (g_kDebugRcpt == g_kWearer) llOwnerSay("From relay: "+sIdent+","+(string)kID+","+sCom+","+sAck);    
+    else if (g_kDebugRcpt) llRegionSayTo(g_kDebugRcpt, DEBUG_CHANNEL, "From relay: "+sIdent+","+(string)kID+","+sCom+","+sAck);    
 }
 
 SafeWord()
@@ -356,7 +357,7 @@ SafeWord()
         integer i;
         for (i=0;i<(g_lSources!=[]);++i)
         {
-            llShout(RELAY_CHANNEL,"release,"+llList2String(g_lSources,i)+",!release,ok");
+            sendrlvr("release", llList2Key(g_lSources, i), "!release", "ok");
         }
         g_lSources=[];
         g_iRecentSafeword = TRUE;
@@ -580,7 +581,7 @@ CleanQueue()
                           list lCommands = llParseString2List(sCommand,["|"],[]);
                           integer j;
                           for (j=0;j<(lCommands!=[]);++j)
-                              llShout(RELAY_CHANNEL,sIdent+","+(string)kObj+","+llList2String(lCommands,j)+",ko");
+                              sendrlvr(sIdent,kObj,llList2String(lCommands,j),"ko");
                         }
                         else
                         {
@@ -641,6 +642,18 @@ default
             {
                 g_iAuthToken=iNum;
                 MinModeMenu(kID);
+                return;
+            }
+            else if (sStr=="relay getdebug")
+            {
+                g_kDebugRcpt = kID;
+                notify(kID, "Relay messages will be forwarded to "+llKey2Name(kID)+".", TRUE);
+                return;
+            }
+            else if (sStr=="relay stopdebug")
+            {
+                g_kDebugRcpt = NULL_KEY;
+                notify(kID, "Relay messages will not forwarded anymore.", TRUE);
                 return;
             }
             else if (iNum==COMMAND_OWNER||kID==g_kWearer)
@@ -993,6 +1006,8 @@ default
         if (llList2Key(lArgs,1)!=g_kWearer && llList2String(lArgs,1)!="ffffffff-ffff-ffff-ffff-ffffffffffff") return; // allow FFF...F wildcard
         string sIdent=llList2String(lArgs,0);
         sMsg=llToLower(llList2String(lArgs,2));
+        if (g_kDebugRcpt == g_kWearer) llOwnerSay("To relay: "+sIdent+","+sMsg);
+        else if (g_kDebugRcpt) llRegionSayTo(g_kDebugRcpt, DEBUG_CHANNEL, "To relay: "+sIdent+","+sMsg);
         if (sMsg == "!pong")
         {//sloppy matching; the protocol document is stricter, but some in-world devices do not respect it
             llMessageLinked(LINK_SET, COMMAND_RLV_RELAY, "ping,"+(string)g_kWearer+",!pong", kID);


### PR DESCRIPTION
```
Issue 1258: relay uses llRegionSayTo, added some debug commands and
documentation
```

and
   Issue 1253: consistently store/restore keys as strings in black/white lists

Maybe I forgot to do the pull request before, or I lost is while reorganizing my repository... anyway now it's here.
