### PR TITLE
Never replace the terminal button in RLV submenu.

### DIFF
--- a/src/collar/oc_rlvsys.lsl
+++ b/src/collar/oc_rlvsys.lsl
@@ -122,12 +122,6 @@ DoMenu(key kID, integer iAuth){
     list lButtons;
     if (g_iRlvActive) {
         lButtons = llListSort(g_lMenu, 1, TRUE);
-        integer iRelay = llListFindList(lButtons,["Relay"]);
-        integer iTerminal = llListFindList(lButtons,["Terminal"]);
-        if (~iRelay && ~iTerminal) { //check if there is a Relay registered and replace the Terminal button with it
-            lButtons = llListReplaceList(lButtons,["Relay"],iTerminal,iTerminal);
-            lButtons = llDeleteSubList(lButtons,iRelay,iRelay);
-        }
         lButtons = [TURNOFF, CLEAR] + lButtons;
     } else if (g_iRLVOff) lButtons = [TURNON];
     else lButtons = [TURNON, TURNOFF];


### PR DESCRIPTION
For some reason unknown to me, oc_rlvsys has some logic that removes the "Terminal" button when a "Relay" button is present.
Terminal and relay are different features, I see no reason for the latter to replace the first. The github "blame" button does not help much here, as the commit message is not very helpful. 

This patch removes this logic (just 6 lines removed).