### PR TITLE
cleanup of oc_exceptions

### DIFF
--- a/src/collar/oc_exceptions.lsl
+++ b/src/collar/oc_exceptions.lsl
@@ -226,25 +226,20 @@ SaveSettings() {
 
 SetAllExs() {
     if (!g_iRLVOn) return;
-    ClearEx(); //Previously this script sets every exception to y or n. It only needs to set y if the exception is already set to n. Either we a: spam the viewer with unset commands as current, b: get current exceptions and parse the list to remove / set as needed, or c: clear exceptions and start from scratch, which is frankly a lot simpler.
+    ClearEx(); //clear all before setting to avoid repeated unsets.
     integer iStop = llGetListLength(g_lRLVcmds);
     integer n;
     integer i;
-    //string sRLVCmd = "@";
-    list lRLVCmd; // Combined RLV commands need comma separation, so let's do it with a list for ease. It's lucky the llOwnerSay commands were being accidentally issued inside the loop for owner/secowner as commas weren't being added, which breaks things. So... yay, a bug that fixed another bug! Let's fix both though.
+    list lRLVCmd;  
     integer iLength = llGetListLength(g_lSecOwners);
     for (n = 0; n < iLength; ++n) {
         string sTmpOwner = llList2String(g_lSecOwners, n);
-        if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) 
-        {
+        if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) {
             for (i = 0; i<iStop; i++) 
             {
                 if (g_iTrustedDefault & llList2Integer(g_lBinCmds, i) )
                     lRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=n";
-                //else
-                    //sRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=y";
-                //llOwnerSay(sRLVCmd);
-                //sRLVCmd = "@";
+                
             }
             if((string)lRLVCmd!="") llOwnerSay("@"+llDumpList2String(lRLVCmd,","));
             lRLVCmd=[];
@@ -253,16 +248,11 @@ SetAllExs() {
     iLength = llGetListLength(g_lOwners+g_lTempOwners);
     for (n = 0; n < iLength; ++n) {
         string sTmpOwner = llList2String(g_lOwners+g_lTempOwners, n);
-        if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) 
-        {
+        if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) {
             for (i = 0; i<iStop; i++) 
             {
                 if (g_iOwnerDefault & llList2Integer(g_lBinCmds, i) )
                     lRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=n";
-               // else
-               //     sRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=y";
-               // llOwnerSay(sRLVCmd);
-               // sRLVCmd = "@";
             }
             if((string)lRLVCmd!="") llOwnerSay("@"+llDumpList2String(lRLVCmd,","));
             lRLVCmd=[];
@@ -272,18 +262,12 @@ SetAllExs() {
     for (n = 0; n < iLength; n += 2) 
     {
         string sTmpOwner = llList2String(g_lSettings, n);
-        if(sTmpOwner!=g_kWearer) 
-        {
+        if(sTmpOwner!=g_kWearer) {
             integer iTmpOwner = llList2Integer(g_lSettings, n+1);
-            for (i = 0; i<iStop; i++) 
-            {
+            for (i = 0; i<iStop; i++) {
                 if (iTmpOwner & llList2Integer(g_lBinCmds, i) )
                     lRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=n";
-                //else
-                    //sRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=y";
             }
-            //llOwnerSay(sRLVCmd);
-            //sRLVCmd = "@";
             if((string)lRLVCmd!="") llOwnerSay("@"+llDumpList2String(lRLVCmd,","));
             lRLVCmd=[];
         }
@@ -291,7 +275,7 @@ SetAllExs() {
 }
 
 ClearEx() {
-     if (g_iRLVOn) llOwnerSay("@clear="+llDumpList2String(g_lRLVcmds,",clear=")); //several times more efficient than looping through the list.
+     if (g_iRLVOn) llOwnerSay("@clear="+llDumpList2String(g_lRLVcmds,",clear=")); 
 }
 
 UserCommand(integer iNum, string sStr, key kID) {
@@ -440,7 +424,7 @@ default {
                 if (sToken == "auth_owner") g_lOwners = llParseString2List(sValue, [","], []);
                 else if (sToken == "auth_trust") g_lSecOwners = llParseString2List(sValue, [","], []);
                 else if (sToken == "auth_tempowner") g_lTempOwners = llParseString2List(sValue, [","], []);
-               // ClearEx();  done in SetAllExs() Now
+              
                 SetAllExs();
             } else if (sToken == "settings") {
                 if (sValue == "sent") SetAllExs();//sendcommands

--- a/src/collar/oc_exceptions.lsl
+++ b/src/collar/oc_exceptions.lsl
@@ -235,11 +235,9 @@ SetAllExs() {
     for (n = 0; n < iLength; ++n) {
         string sTmpOwner = llList2String(g_lSecOwners, n);
         if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) {
-            for (i = 0; i<iStop; i++) 
-            {
+            for (i = 0; i<iStop; i++) {
                 if (g_iTrustedDefault & llList2Integer(g_lBinCmds, i) )
                     lRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=n";
-                
             }
             if((string)lRLVCmd!="") llOwnerSay("@"+llDumpList2String(lRLVCmd,","));
             lRLVCmd=[];
@@ -249,8 +247,7 @@ SetAllExs() {
     for (n = 0; n < iLength; ++n) {
         string sTmpOwner = llList2String(g_lOwners+g_lTempOwners, n);
         if (llListFindList(g_lSettings, [sTmpOwner]) == -1 && sTmpOwner!=g_kWearer) {
-            for (i = 0; i<iStop; i++) 
-            {
+            for (i = 0; i<iStop; i++) {
                 if (g_iOwnerDefault & llList2Integer(g_lBinCmds, i) )
                     lRLVCmd += llList2String(g_lRLVcmds, i) + ":" + sTmpOwner + "=n";
             }
@@ -259,8 +256,7 @@ SetAllExs() {
         }
     }
     iLength = llGetListLength(g_lSettings);
-    for (n = 0; n < iLength; n += 2) 
-    {
+    for (n = 0; n < iLength; n += 2) {
         string sTmpOwner = llList2String(g_lSettings, n);
         if(sTmpOwner!=g_kWearer) {
             integer iTmpOwner = llList2Integer(g_lSettings, n+1);


### PR DESCRIPTION
I've done some clean up of the oc_exceptions code. 

Firstly, a bug fix. Exception commands were being issued in the SetAllExs() routine one at a time, rather than be concatenated onto a single line. From the looks of it this is an error? The code retains the basic shape I remember working on back in the 3.9 days, but commands were added to the string and then the string issued as an RLV command in each loop through the various exceptions rather than the entire string being issued in one go. 

Secondly, the way the commands were being looped was to issue a y or n regardless of whether it is needed. Thus exceptions that have never been set are being unset, just in case there's actually a change. Ideally this ought to be being tracked properly, but this choice was obviously taken as a way to avoid having to track the changes. However it's simpler and more compact to just remove all exceptions and then reapply, so I use ClearEx() at the beginning of the SetAllExs() routine. 

Thirdly, I have changed ClearEx() to issue all the exception commands in a single string by dumping the loop to a string rather than looping and issuing a command for each. This is a lot faster and cleaner. 

As a result, this drops the number of llOwnerSays from seven per unique avatar in owner lists (some of them clearing unset exceptions) to one call to clear plus one per unique avatar, and will generally reduce the number of RLV commands issued overall by a variable amount depending on user settings. 

I've commented my code changes in the code for easy reference. 

Further notes:
1.  I find the approach to this a little messy with the remove/reapply exceptions thing, and even with these fixes we have the bizarre result that this script will still clear all exceptions on login, when obviously no exceptions are set. However this is a consequence of the way the collar reasserts on rez, and short of a major architectural change, I'm not sure there's any simple way of cleaning this up further, or whether it's worth bothering with further optimisation anyway.

2. It bugs the hell out of me to see an llResetScript() on attach. This isn't simulator friendly behaviour, but I'm not familiar enough with the on rez behaviour of the collar  yet to look to cleaning that up. Again the major architectural changes thing. 