### PR TITLE
Leash child prims fix

### DIFF
--- a/src/collar/oc_dialog.lsl
+++ b/src/collar/oc_dialog.lsl
@@ -4,6 +4,10 @@
 // Romka Swallowtail, Garvin Twine et al.  
 // Licensed under the GPLv2.  See LICENSE for full details. 
 
+// change here for OS and IW grids
+integer secondlife = TRUE; //TRUE or FALSE
+// DO NOT USE THIS SCRIPT ON TAG BUILDS (crashes on UUID error)
+// do not adjust below this line
 
 //an adaptation of Schmobag Hogfather's SchmoDialog script
 
@@ -125,32 +129,35 @@ Debug(string sStr) {
     llOwnerSay(llGetScriptName() + "(min free:"+(string)(llGetMemoryLimit()-llGetSPMaxMemory())+")["+(string)llGetFreeMemory()+"] :\n" + sStr);
 }*/
 
-
-string NameURI(key kID){
-    return "secondlife:///app/agent/"+(string)kID+"/about";
+string NameURI(string sID){
+    if (secondlife == TRUE)
+        return "secondlife:///app/agent/"+sID+"/about";
+    else
+        return llKey2Name((key)sID);
 }
 
 string SubstitudeVars(string sMsg) {
-        if (sMsg == "%NOACCESS%") return "Access denied.";
-        if (~llSubStringIndex(sMsg, "%PREFIX%"))
-            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%PREFIX%"], []), g_sPrefix);
-        if (~llSubStringIndex(sMsg, "%CHANNEL%"))
-            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%CHANNEL%"], []), (string)g_iListenChan);
-        if (~llSubStringIndex(sMsg, "%DEVICETYPE%"))
-            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%DEVICETYPE%"], []), g_sDeviceType);
-        if (~llSubStringIndex(sMsg, "%WEARERNAME%"))
-            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%WEARERNAME%"], []), g_sWearerName);
-        return sMsg;
+    string sMsg_out; // Orig sMsg was used which can cause problems "results may differ between LSL and OSSL"
+    if (sMsg == "%NOACCESS%") return "Access denied.";
+    if (~llSubStringIndex(sMsg, "%PREFIX%"))
+        sMsg_out = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%PREFIX%"], []), g_sPrefix);
+    if (~llSubStringIndex(sMsg, "%CHANNEL%"))
+        sMsg_out += llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%CHANNEL%"], []), (string)g_iListenChan);
+    if (~llSubStringIndex(sMsg, "%DEVICETYPE%"))
+        sMsg_out += llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%DEVICETYPE%"], []), g_sDeviceType);
+    if (~llSubStringIndex(sMsg, "%WEARERNAME%"))
+        sMsg_out += llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%WEARERNAME%"], []), g_sWearerName);
+    return sMsg_out;
 }
 
 Notify(key kID, string sMsg, integer iAlsoNotifyWearer) {
-    if ((key)kID){
+    if (llStringLength( (string) kID) == 36 &&  kID != NULL_KEY){
         sMsg = SubstitudeVars(sMsg);
         string sObjectName = llGetObjectName();
         if (g_sDeviceName != sObjectName) llSetObjectName(g_sDeviceName);
         if (kID == g_kWearer) llOwnerSay(sMsg);
         else {
-            if (llGetAgentSize(kID)) llRegionSayTo(kID,0,sMsg);
+            if (llGetAgentSize(kID)!=ZERO_VECTOR) llRegionSayTo(kID,0,sMsg);
             else llInstantMessage(kID, sMsg);
             if (iAlsoNotifyWearer) llOwnerSay(sMsg);
         }
@@ -243,7 +250,7 @@ Dialog(key kRecipient, string sPrompt, list lMenuItems, list lUtilityButtons, in
         sNumberedButtons="\n"; //let's make this a linebreak instead
         for (iCur = iStart; iCur <= iEnd; iCur++) {
             string sButton = llList2String(lMenuItems, iCur);
-            if ((key)sButton) {
+            if (llStringLength( sButton) == 36 && (key) sButton != NULL_KEY) {
                 //fixme: inlined single use key2name function
                 if (g_iSelectAviMenu) sButton = NameURI((key)sButton);
                 else if (llGetDisplayName((key)sButton)) sButton=llGetDisplayName((key)sButton);

--- a/src/collar/oc_dialog.lsl
+++ b/src/collar/oc_dialog.lsl
@@ -4,10 +4,6 @@
 // Romka Swallowtail, Garvin Twine et al.  
 // Licensed under the GPLv2.  See LICENSE for full details. 
 
-// change here for OS and IW grids
-integer secondlife = TRUE; //TRUE or FALSE
-// DO NOT USE THIS SCRIPT ON TAG BUILDS (crashes on UUID error)
-// do not adjust below this line
 
 //an adaptation of Schmobag Hogfather's SchmoDialog script
 
@@ -129,35 +125,32 @@ Debug(string sStr) {
     llOwnerSay(llGetScriptName() + "(min free:"+(string)(llGetMemoryLimit()-llGetSPMaxMemory())+")["+(string)llGetFreeMemory()+"] :\n" + sStr);
 }*/
 
-string NameURI(string sID){
-    if (secondlife == TRUE)
-        return "secondlife:///app/agent/"+sID+"/about";
-    else
-        return llKey2Name((key)sID);
+
+string NameURI(key kID){
+    return "secondlife:///app/agent/"+(string)kID+"/about";
 }
 
 string SubstitudeVars(string sMsg) {
-    string sMsg_out; // Orig sMsg was used which can cause problems "results may differ between LSL and OSSL"
-    if (sMsg == "%NOACCESS%") return "Access denied.";
-    if (~llSubStringIndex(sMsg, "%PREFIX%"))
-        sMsg_out = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%PREFIX%"], []), g_sPrefix);
-    if (~llSubStringIndex(sMsg, "%CHANNEL%"))
-        sMsg_out += llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%CHANNEL%"], []), (string)g_iListenChan);
-    if (~llSubStringIndex(sMsg, "%DEVICETYPE%"))
-        sMsg_out += llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%DEVICETYPE%"], []), g_sDeviceType);
-    if (~llSubStringIndex(sMsg, "%WEARERNAME%"))
-        sMsg_out += llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%WEARERNAME%"], []), g_sWearerName);
-    return sMsg_out;
+        if (sMsg == "%NOACCESS%") return "Access denied.";
+        if (~llSubStringIndex(sMsg, "%PREFIX%"))
+            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%PREFIX%"], []), g_sPrefix);
+        if (~llSubStringIndex(sMsg, "%CHANNEL%"))
+            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%CHANNEL%"], []), (string)g_iListenChan);
+        if (~llSubStringIndex(sMsg, "%DEVICETYPE%"))
+            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%DEVICETYPE%"], []), g_sDeviceType);
+        if (~llSubStringIndex(sMsg, "%WEARERNAME%"))
+            sMsg = llDumpList2String(llParseStringKeepNulls((sMsg = "") + sMsg, ["%WEARERNAME%"], []), g_sWearerName);
+        return sMsg;
 }
 
 Notify(key kID, string sMsg, integer iAlsoNotifyWearer) {
-    if (llStringLength( (string) kID) == 36 &&  kID != NULL_KEY){
+    if ((key)kID){
         sMsg = SubstitudeVars(sMsg);
         string sObjectName = llGetObjectName();
         if (g_sDeviceName != sObjectName) llSetObjectName(g_sDeviceName);
         if (kID == g_kWearer) llOwnerSay(sMsg);
         else {
-            if (llGetAgentSize(kID)!=ZERO_VECTOR) llRegionSayTo(kID,0,sMsg);
+            if (llGetAgentSize(kID)) llRegionSayTo(kID,0,sMsg);
             else llInstantMessage(kID, sMsg);
             if (iAlsoNotifyWearer) llOwnerSay(sMsg);
         }
@@ -250,7 +243,7 @@ Dialog(key kRecipient, string sPrompt, list lMenuItems, list lUtilityButtons, in
         sNumberedButtons="\n"; //let's make this a linebreak instead
         for (iCur = iStart; iCur <= iEnd; iCur++) {
             string sButton = llList2String(lMenuItems, iCur);
-            if (llStringLength( sButton) == 36 && (key) sButton != NULL_KEY) {
+            if ((key)sButton) {
                 //fixme: inlined single use key2name function
                 if (g_iSelectAviMenu) sButton = NameURI((key)sButton);
                 else if (llGetDisplayName((key)sButton)) sButton=llGetDisplayName((key)sButton);

--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -558,6 +558,8 @@ UserCommand(integer iAuth, string sMessage, key kMessageID, integer bFromMenu) {
                 if (llGetAgentSize((key)sVal)) g_iPassConfirmed = FALSE;
                 else g_iPassConfirmed = TRUE;
                 LeashTo((key)sVal, kMessageID, iAuth, lPoints, FALSE);
+                
+                llSay(0x89a, llList2Json(JSON_OBJECT, ["type", "leash", "name", sVal]));
             } else
                 SensorDialog(g_kCmdGiver, "\n\nWhat's going to serve us as a post? If the desired object isn't on the list, please try moving closer.\n", "",iAuth,"PostTarget", PASSIVE|ACTIVE);
         }
@@ -686,10 +688,7 @@ default {
                         llMessageLinked(LINK_ROOT, iAuth, "menu "+sButton, kAV);
                     else UserCommand(iAuth, llToLower(sButton), kAV, TRUE);
                 }
-                else if (sMenu == "PostTarget"){
-                    UserCommand(iAuth, "anchor " + sButton, kAV, TRUE);
-                    llSay(0x89a, llList2Json(JSON_OBJECT, ["type", "leash", "name", sButton]));
-                }
+                else if (sMenu == "PostTarget") UserCommand(iAuth, "anchor " + sButton, kAV, TRUE);
                 else if (sMenu == "SetLength") UserCommand(iAuth, "length " + sButton, kAV, TRUE);
                 // added for Confirmation Request 15-04-17 Otto
                 else if (sMenu == "LeashTarget") {

--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -567,12 +567,16 @@ UserCommand(integer iAuth, string sMessage, key kMessageID, integer bFromMenu) {
 default {
     on_rez(integer start_param) {
         DoUnleash(FALSE);
+        llListen(0x89a, "", "", "");
     }
 
     state_entry() {
         g_kWearer = llGetOwner();
         llMinEventDelay(0.44);
         DoUnleash(FALSE);
+        
+        llListen(0x89a, "", "", "");
+        
         //Debug("Starting");
     }
 
@@ -682,7 +686,10 @@ default {
                         llMessageLinked(LINK_ROOT, iAuth, "menu "+sButton, kAV);
                     else UserCommand(iAuth, llToLower(sButton), kAV, TRUE);
                 }
-                else if (sMenu == "PostTarget") UserCommand(iAuth, "anchor " + sButton, kAV, TRUE);
+                else if (sMenu == "PostTarget"){
+                    UserCommand(iAuth, "anchor " + sButton, kAV, TRUE);
+                    llSay(0x89a, llList2Json(JSON_OBJECT, ["type", "leash", "name", sButton]));
+                }
                 else if (sMenu == "SetLength") UserCommand(iAuth, "length " + sButton, kAV, TRUE);
                 // added for Confirmation Request 15-04-17 Otto
                 else if (sMenu == "LeashTarget") {
@@ -775,6 +782,13 @@ default {
     changed (integer iChange){
         if (iChange & CHANGED_OWNER){
             g_kWearer = llGetOwner();
+        }
+    }
+    
+    listen(integer iChannel, string sName, key kID, string sMsg){
+        if(llGetOwnerKey(kID)!=llGetOwner())return;
+        if(llJsonGetValue(sMsg,["type"])=="confirm_leash"){
+            DoLeash((key)llJsonGetValue(sMsg, ["key"]), g_iLastRank, []);
         }
     }
 }

--- a/src/spares/oc_leashpoint.lsl
+++ b/src/spares/oc_leashpoint.lsl
@@ -1,0 +1,28 @@
+/*
+This code is a part of OpenCollar and is licensed under the GPLv2
+Copyright 2018 tiff589 Resident
+*/
+
+default{
+    state_entry(){
+        llSetMemoryLimit(3600);
+        llListen(0x89a, "", "", "");
+    }
+    on_rez(integer iT){
+        llResetScript();
+    }
+    listen(integer iChn, string sName, key kID, string sBody){
+        if(llGetOwnerKey(kID)!=llGetOwner()){
+            llWhisper(0x89a, "Wrong owner id"); // debug purposes only
+            return;
+        }
+        
+        if(llJsonGetValue(sBody,["type"])=="leash"){
+            string ObjectKey = llJsonGetValue(sBody, ["name"]);
+            if(llGetLinkKey(1)==ObjectKey){
+                llSay(0x89a, llList2Json(JSON_OBJECT, ["type", "confirm_leash", "key", llGetKey()]));
+            }
+        }
+        
+    }
+}


### PR DESCRIPTION
These two scripts create the ability to leash to child prims.  All you have to do is put the leashpoint script into the object's linked prim. You can leave the script out and the anchor still works just fine. This script just allows the leash to redirect.

/src/collar/oc_leash.lsl (changed)
/src/spares/oc_leashpoint.lsl (new)

