### PR TITLE
Fix backward compatibility with Apps using AddOns menu

### DIFF
--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -500,6 +500,7 @@ RebuildMenu() {
     g_lAppsButtons = [] ;
     llMessageLinked(LINK_SET, MENUNAME_REQUEST, "Main", "");
     llMessageLinked(LINK_SET, MENUNAME_REQUEST, "Apps", "");
+    llMessageLinked(LINK_SET, MENUNAME_REQUEST, "AddOns", "");
     llMessageLinked(LINK_SET, MENUNAME_REQUEST, "Settings", "");
     llMessageLinked(LINK_ALL_OTHERS, LINK_UPDATE,"LINK_REQUEST","");
 }


### PR DESCRIPTION
This alone seems to fix #183 
Most of the code required to implement the backwards compatibility is already present, just missing the request message.

I couldn't test it with an old plugin (couldn't find one). So I only tested with a new plugin changing the value of `g_sParentMenu` from `Apps` to `AddOns`