### PR TITLE
Update oc_leash.lsl

### DIFF
--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -617,8 +617,7 @@ LHSearch(){
     else{
         for(iBegin=0;iBegin<iEnd;iBegin++){
             string sItem  = llGetInventoryName(INVENTORY_OBJECT,iBegin);
-            sItem = llToLower(sItem);
-            if(llSubStringIndex(sItem,"leashholder")!=-1){
+            if(llSubStringIndex(llToLower(sItem),"leashholder")!=-1){
                 g_sLeashHolder=llGetInventoryName(INVENTORY_OBJECT, iBegin);
                 sItem="";
                 iBegin=0;

--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -5,7 +5,7 @@
 // Sumi Perl, Karo Weirsider, Kurt Burleigh, Marissa Mistwallow et al.   
 // Licensed under the GPLv2.  See LICENSE for full details. 
 
-string g_sScriptVersion = "7.2rc";
+string g_sScriptVersion = "7.2";
 integer LINK_CMD_DEBUG=1999;
 
 // ------ TOKEN DEFINITIONS ------
@@ -618,7 +618,7 @@ LHSearch(){
         for(iBegin=0;iBegin<iEnd;iBegin++){
             string sItem  = llGetInventoryName(INVENTORY_OBJECT,iBegin);
             if(llSubStringIndex(llToLower(sItem),"leashholder")!=-1){
-                g_sLeashHolder=llGetInventoryName(INVENTORY_OBJECT, iBegin);
+                g_sLeashHolder=sItem;
                 sItem="";
                 iBegin=0;
                 iEnd=0;


### PR DESCRIPTION
Check for leashholder was dropping to lower case for the string matching, but retaining the lower case version. This means leash holder giving fails when caps are present in the object name. llToLower() moved to comparison to retain case.