### PR TITLE
Update oc_leash.lsl

### DIFF
--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -557,7 +557,7 @@ UserCommand(integer iAuth, string sMessage, key kMessageID, integer bFromMenu) {
         } else if (sComm == "length") {
             integer iNewLength = (integer)sVal;
             if (sVal==llToLower(BUTTON_UPMENU)){
-                UserCommand(iAuth, "leash", kMessageID ,bFromMenu);
+                UserCommand(iAuth, "leashmenu", kMessageID ,bFromMenu);
             } else if(iNewLength > 0 && iNewLength <= 60){
                 //Person holding the leash can always set length.
                 if (kMessageID == g_kLeashedTo || CheckCommandAuth(kMessageID, iAuth)) {


### PR DESCRIPTION
Fix to back button behaviour in length submenu.

Typo issued a leash usercommand instead of leashmenu usercommand when back button clicked in leash length submenu. Result was that visiting the leash length menu and going back caused the leash to be grabbed. 