### PR TITLE
Add support for multiple lines in oc_meshlabel

### DIFF
--- a/src/collar/oc_meshlabel.lsl
+++ b/src/collar/oc_meshlabel.lsl
@@ -6,6 +6,22 @@
 // Garvin Twine et al.   
 // Licensed under the GPLv2.  See LICENSE for full details. 
 
+// How to use:
+// 
+// - You need a Mesh-Strip with 6 Faces next to each other. Each Face should have 1 Material.
+// - Link the Strips together next to each other. 
+// - Name them like this: MeshLabel~number~line
+//      number is the mesh-number from 0 to how many you linked horizontally   
+//      line is the vertical number from 0 to how many lines you have
+//
+//  Example:
+//          ***************** ***************** *****************
+//          * MeshLabel~0~0 * * MeshLabel~1~0 * * MeshLabel~2~0 *
+//          ***************** ***************** *****************
+//
+//          ***************** ***************** *****************
+//          * MeshLabel~0~1 * * MeshLabel~1~1 * * MeshLabel~2~1 *
+//          ***************** ***************** *****************
 
 string g_sAppVersion = "1.1";
 string g_sScriptVersion = "7.3";
@@ -48,11 +64,11 @@ integer DIALOG = -9000;
 integer DIALOG_RESPONSE = -9001;
 integer DIALOG_TIMEOUT = -9002;
 
-integer g_iCharLimit = -1;
+list g_lCharLimit = [];
 
 string UPMENU = "BACK";
 
-string g_sTextMenu = "Set Label";
+string g_sTextMenu = "Set Line ";
 string g_sFontMenu = "Font";
 string g_sColorMenu = "Color";
 
@@ -71,12 +87,12 @@ key g_kFontTexture = "91b730bc-b763-52d4-d091-260eddda3198";
 integer x = 45;
 integer y = 19;
 
-integer faces = 6;
+integer faces = 6; // Default would be 6
 
 float g_fScrollTime = 0.3 ;
-integer g_iSctollPos ;
-string g_sScrollText;
-list g_lLabelLinks ;
+list g_lScrollPos ;
+list g_lScrollText;
+list g_lLabelLinks;
 list g_lLabelBaseElements;
 list g_lGlows;
 
@@ -85,7 +101,7 @@ integer g_iShow;
 vector g_vColor = <1,1,1>;
 integer g_iHide;
 
-string g_sLabelText = "";
+list g_lLabelText = [""];
 string g_sSettingToken = "label_";
 //string g_sGlobalToken = "global_";
 
@@ -114,10 +130,10 @@ integer GetIndex(string sChar) {
     else return 854;
 }
 
-RenderString(integer iPos, string sChar) {  // iPos - позиция символа на лейбле
+RenderString(integer iPos, string sChar, integer iLineNum) {  // iPos - позиция символа на лейбле
     integer frame = GetIndex(sChar);  //номер символа в таблице
     integer i = iPos/faces;
-    integer link = llList2Integer(g_lLabelLinks,i);
+    integer link = llList2Integer(llParseString2List(llList2String(g_lLabelLinks,iLineNum),["|"],[]),i);
     integer face = iPos - faces * i;
     integer frameY = frame / x;
     integer frameX = frame - x * frameY;
@@ -127,12 +143,18 @@ RenderString(integer iPos, string sChar) {  // iPos - позиция симво�
 }
 
 SetColor() {
-    integer i=0;
-    do {
-        integer iLink = llList2Integer(g_lLabelLinks,i);
-        float fAlpha = llList2Float(llGetLinkPrimitiveParams( iLink,[PRIM_COLOR,ALL_SIDES]),1);
-        llSetLinkPrimitiveParamsFast(iLink, [PRIM_COLOR, ALL_SIDES, g_vColor, fAlpha]);
-    } while (++i < llGetListLength(g_lLabelLinks));
+
+    integer iLine;
+    for (iLine=0;iLine<llGetListLength(g_lLabelLinks);++iLine)
+    {
+        list lLinkList = llParseString2List(llList2String(g_lLabelLinks,iLine),["|"],[]);
+        integer i=0;
+        do {
+            integer iLink = llList2Integer(lLinkList,i);
+            float fAlpha = llList2Float(llGetLinkPrimitiveParams( iLink,[PRIM_COLOR,ALL_SIDES]),1);
+            llSetLinkPrimitiveParamsFast(iLink, [PRIM_COLOR, ALL_SIDES, g_vColor, fAlpha]);
+        } while (++i < llGetListLength(lLinkList));
+    }
 }
 // find all 'Label' prims, count and store it's link numbers for fast work SetLabel() and timer
 integer LabelsCount() {
@@ -148,21 +170,41 @@ integer LabelsCount() {
         lTmp = llParseString2List(llList2String(llGetLinkPrimitiveParams(iLink,[PRIM_NAME]),0), ["~"],[]);
         sLabel = llList2String(lTmp,0);
         if(sLabel == "MeshLabel") {
-            g_lLabelLinks += [0]; // fill list witn nulls
+            integer iLine = 0;
+            if (llGetListLength(lTmp)>2) iLine = llList2Integer(lTmp,2);
+            else iLine = 0;
+            if (iLine > llGetListLength(g_lLabelLinks)-1) g_lLabelLinks += [""]; // Add new Line
+            list lLineLinks = llParseString2List(llList2String(g_lLabelLinks,iLine),["|"],[]);
+            lLineLinks += [0]; // Fill with Zero
+            g_lLabelLinks = llListReplaceList(g_lLabelLinks,[llDumpList2String(lLineLinks,"|")],iLine,iLine);
             //change prim description
             llSetLinkPrimitiveParamsFast(iLink,[PRIM_DESC,"Label~notexture~nocolor~nohide~noshiny"]);
         } else if (sLabel == "LabelBase") g_lLabelBaseElements += iLink;
     }
-    g_iCharLimit = llGetListLength(g_lLabelLinks) * 6;
+    integer i;
+    for (i=0; i<llGetListLength(g_lLabelLinks);++i)
+    {
+        list lLineLinks = llParseString2List(llList2String(g_lLabelLinks,i),["|"],[]);
+        g_lCharLimit = llListReplaceList(g_lCharLimit,[llGetListLength(lLineLinks) * faces],i,i);
+    }
     //find all 'Label' prims and store it's links to list
     for(iLink=2; iLink <= iLinkCount; iLink++) {
         lTmp = llParseString2List(llList2String(llGetLinkPrimitiveParams(iLink,[PRIM_NAME]),0), ["~"],[]);
         sLabel = llList2String(lTmp,0);
         if (sLabel == "MeshLabel") {
             integer iLabel = (integer)llList2String(lTmp,1);
-            integer link = llList2Integer(g_lLabelLinks,iLabel);
-            if (link == 0)
-                g_lLabelLinks = llListReplaceList(g_lLabelLinks,[iLink],iLabel,iLabel);
+            integer iLine = 0;
+            if (llGetListLength(lTmp) > 2) iLine = llList2Integer(lTmp,2); // keep it compatible with old single-line version
+            integer link = -1;
+            
+            list lLineList = llParseString2List(llList2String(g_lLabelLinks,iLine),["|"],[]);
+            
+            link = llList2Integer(lLineList,iLabel);
+            if (link == 0) 
+            {
+                lLineList = llListReplaceList(lLineList, [iLink], iLabel, iLabel);
+                g_lLabelLinks = llListReplaceList(g_lLabelLinks, [llDumpList2String(lLineList,"|")], iLine, iLine);
+            }
             else {
                 ok = FALSE;
                 llOwnerSay("Warning! Found duplicated label prims: "+sLabel+" with link numbers: "+(string)link+" and "+(string)iLink);
@@ -172,7 +214,7 @@ integer LabelsCount() {
     if (!ok) {
         if (~llSubStringIndex(llGetObjectName(),"Installer") && ~llSubStringIndex(llGetObjectName(),"Updater"))
             return 1;
-    }
+    } else SetLabel();
     return ok;
 }
 
@@ -202,24 +244,39 @@ UpdateGlow(integer iLink, integer iAlpha) {
     }
 }   
 
-SetLabel() {
-    string sText ;
-    if (g_iShow) sText = g_sLabelText;
-
+SetLine(integer iNumber, string sText)
+{
     string sPadding;
     if(g_iScroll==TRUE) {
-        while(llStringLength(sPadding) < g_iCharLimit) sPadding += " ";
-        g_sScrollText = sPadding + sText;
+        while(llStringLength(sPadding) < llList2Integer(g_lCharLimit,iNumber)) sPadding += " ";
+        g_lScrollText = llListReplaceList(g_lScrollText,[sPadding + sText],iNumber,iNumber);
         llSetTimerEvent(g_fScrollTime);
     } else {
-        g_sScrollText = "";
+        g_lScrollText = [];
         llSetTimerEvent(0);
         //inlined single use CenterJustify function
-        while(llStringLength(sPadding + sText + sPadding) < g_iCharLimit) sPadding += " ";
+        while(llStringLength(sPadding + sText + sPadding) < llList2Integer(g_lCharLimit,iNumber)) sPadding += " ";
         sText = sPadding + sText;
         integer iCharPosition;
-        for(iCharPosition=0; iCharPosition < g_iCharLimit; iCharPosition++)
-            RenderString(iCharPosition, llGetSubString(sText, iCharPosition, iCharPosition));
+        for(iCharPosition=0; iCharPosition < llList2Integer(g_lCharLimit,iNumber); iCharPosition++)
+            RenderString(iCharPosition, llGetSubString(sText, iCharPosition, iCharPosition), iNumber);
+    }
+}
+
+SetLabel() {
+    if (llGetListLength(g_lLabelLinks) > 2) g_iScroll = FALSE; // No scrolling with more than 2 lines!
+    if (g_iShow){
+        integer i;
+        for (i=0; i<llGetListLength(g_lLabelText);++i)
+        {
+            SetLine(i,llList2String(g_lLabelText,i));
+        }
+    } else {
+        integer i;
+        for (i=0; i<llGetListLength(g_lLabelText);++i)
+        {
+            SetLine(i," ");
+        }
     }
 }
 
@@ -232,20 +289,30 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
 }
 
 MainMenu(key kID, integer iAuth) {
-    list lButtons= [g_sTextMenu, g_sColorMenu, g_sFontMenu];
+    list lButtons=[];
+    integer i;
+    for (i=0; i<llGetListLength(g_lLabelLinks); ++i)
+    {
+        lButtons += [g_sTextMenu+(string)(i+1)];
+    }
+    
+    lButtons += [g_sColorMenu, g_sFontMenu];
     if (g_iShow) lButtons += ["☑ Show"];
     else lButtons += ["☐ Show"];
 
-    if (g_iScroll) lButtons += ["☑ Scroll"];
-    else lButtons += ["☐ Scroll"];
+    if (llGetListLength(g_lLabelLinks) < 3)  // Too much work to scroll more than 2 lines.
+    {
+        if (g_iScroll) lButtons += ["☑ Scroll"];
+        else lButtons += ["☐ Scroll"];
+    }
 
     string sPrompt = "\n[Label]\t"+g_sAppVersion+"\n\nCustomize the %DEVICETYPE%'s label!";
     Dialog(kID, sPrompt, lButtons, [UPMENU], 0, iAuth,"main");
 }
 
-TextMenu(key kID, integer iAuth) {
+TextMenu(key kID, integer iAuth, integer iLineNum) {
     string sPrompt="\n- Submit the new label in the field below.\n- Submit a few spaces to clear the label.\n- Submit a blank field to go back to " + g_sSubMenu + ".";
-    Dialog(kID, sPrompt, [], [], 0, iAuth,"textbox");
+    Dialog(kID, sPrompt, [], [], 0, iAuth,"textbox"+(string)iLineNum);
 }
 
 ColorMenu(key kID, integer iAuth) {
@@ -279,7 +346,7 @@ UserCommand(integer iAuth, string sStr, key kAv) {
         string sCommand = llToLower(llList2String(lParams, 0));
         string sAction = llToLower(llList2String(lParams, 1));
         string sValue = llToLower(llList2String(lParams, 2));
-        if (sCommand == "label") {
+        if (sCommand == "label" || llGetSubString(sCommand,0,-2) == "label") {
             if (sAction == "font") {
                 string font = llDumpList2String(llDeleteSubList(lParams,0,1)," ");
                 integer iIndex = llListFindList(g_lFonts, [font]);
@@ -307,12 +374,20 @@ UserCommand(integer iAuth, string sStr, key kAv) {
                 else if (sValue == "off") g_iScroll = FALSE;
                 llMessageLinked(LINK_SAVE, LM_SETTING_SAVE, g_sSettingToken+"scroll="+(string)g_iScroll, "");
             } else {
-                g_sLabelText = llStringTrim(llDumpList2String(llDeleteSubList(lParams,0,0)," "),STRING_TRIM);
-                llMessageLinked(LINK_SAVE, LM_SETTING_SAVE, g_sSettingToken + "text=" + g_sLabelText, "");
-                if (llStringLength(g_sLabelText) > g_iCharLimit) {
-                    string sDisplayText = llGetSubString(g_sLabelText, 0, g_iCharLimit-1);
-                    llMessageLinked(LINK_DIALOG, NOTIFY, "0"+"Unless your set your label to scroll it will be truncted at "+sDisplayText+".", kAv);
-                }
+                
+                integer iLine;
+                if (llGetSubString(sCommand,-1,-1) == "t") iLine = 0;
+                else iLine = ((integer)llGetSubString(sCommand,-1,-1));
+                string sNewText = llStringTrim(llDumpList2String(llDeleteSubList(lParams,0,0)," "),STRING_TRIM);
+                g_lLabelText = llListReplaceList(g_lLabelText,[sNewText],iLine, iLine);
+                llMessageLinked(LINK_SAVE, LM_SETTING_SAVE, g_sSettingToken + "text"+(string)iLine+"=" + sNewText, "");
+                if (!g_iShow)
+                    llMessageLinked(LINK_DIALOG, NOTIFY, "0"+"The label is actually disabled, it will not show up until you enable it.", kAv);
+                
+                if (llStringLength(sNewText) > llList2Integer(g_lCharLimit,iLine)) {
+                        string sDisplayText = llGetSubString(sNewText, 0, llList2Integer(g_lCharLimit,iLine)-1);
+                        llMessageLinked(LINK_DIALOG, NOTIFY, "0"+"Unless your set your label to scroll it will be truncted at "+sDisplayText+".", kAv);
+                    }
             }
             SetLabel();
         }
@@ -333,8 +408,8 @@ default
         g_kWearer = llGetOwner();
         Ureps = (float)1 / x;
         Vreps = (float)1 / y;
-        LabelsCount();
-        if (g_iCharLimit <= 0) {
+        if (LabelsCount()==TRUE) SetLabel();
+        if (llGetListLength(g_lLabelLinks) < 1) {
             llMessageLinked(LINK_SET, MENUNAME_REMOVE, g_sParentMenu + "|" + g_sSubMenu, "");
             llRemoveInventory(llGetScriptName());
         }
@@ -343,7 +418,7 @@ default
 
     on_rez(integer iNum) {
         if (g_kWearer != llGetOwner()) {
-            g_sLabelText = "";
+            g_lLabelText = [];
             SetLabel();
         }
         llResetScript();
@@ -358,7 +433,7 @@ default
             integer i = llSubStringIndex(sToken, "_");
             if (llGetSubString(sToken, 0, i) == g_sSettingToken) {
                 sToken = llGetSubString(sToken, i + 1, -1);
-                if (sToken == "text") g_sLabelText = sValue;
+                if (llGetSubString(sToken,0,-2) == "text") g_lLabelText = llListReplaceList(g_lLabelText,[sValue],(integer)llGetSubString(sToken,-1,-1),(integer)llGetSubString(sToken,-1,-1));
                 else if (sToken == "font") g_kFontTexture = (key)sValue;
                 else if (sToken == "color") g_vColor = (vector)sValue;
                 else if (sToken == "show") g_iShow = (integer)sValue;
@@ -382,7 +457,7 @@ default
                 if (sMenuType=="main") {
                     //got a menu response meant for us.  pull out values
                     if (sMessage == UPMENU) llMessageLinked(LINK_ROOT, iAuth, "menu " + g_sParentMenu, kAv);
-                    else if (sMessage == g_sTextMenu) TextMenu(kAv, iAuth);
+                    else if (llGetSubString(sMessage,0,-2) == g_sTextMenu) TextMenu(kAv, iAuth, ((integer)llGetSubString(sMessage,-1,-1))-1);
                     else if (sMessage == g_sColorMenu) ColorMenu(kAv, iAuth);
                     else if (sMessage == g_sFontMenu) FontMenu(kAv, iAuth);
                     else if (sMessage == "☐ Show") {
@@ -410,12 +485,12 @@ default
                         UserCommand(iAuth, "label font " + sMessage, kAv);
                         FontMenu(kAv, iAuth);
                     }
-                } else if (sMenuType == "textbox") { // TextBox response, extract values
-                    if (sMessage != " ") UserCommand(iAuth, "label " + sMessage, kAv);
+                } else if (llGetSubString(sMenuType,0,-2) == "textbox") { // TextBox response, extract values
+                    if (sMessage != " ") UserCommand(iAuth, "label"+llGetSubString(sMenuType,-1,-1)+" " + sMessage, kAv);
                     UserCommand(iAuth, "menu " + g_sSubMenu, kAv);
                 } else if (sMenuType == "rmlabel") {
                     if (sMessage == "Yes") {
-                        if (g_sScrollText) UserCommand(iAuth, "label scroll off", kAv);
+                        if (llGetListLength(g_lScrollText) > 0) UserCommand(iAuth, "label scroll off", kAv);
                         llMessageLinked(LINK_ROOT, MENUNAME_REMOVE , g_sParentMenu + "|" + g_sSubMenu, "");
                         llMessageLinked(LINK_DIALOG, NOTIFY, "1"+g_sSubMenu+" App has been removed.", kAv);
                     if (llGetInventoryType(llGetScriptName()) == INVENTORY_SCRIPT) llRemoveInventory(llGetScriptName());
@@ -436,17 +511,28 @@ default
             llInstantMessage(kID, llGetScriptName() +" SCRIPT VERSION: "+g_sScriptVersion);
             llInstantMessage(kID, llGetScriptName()+" APP VERSION: "+g_sAppVersion);
             if(onlyver)return; // basically this command was: <prefix> versions
-            llInstantMessage(kID, llGetScriptName()+" LABEL "+g_sLabelText);
+            integer i;
+            for (i=0; i<llGetListLength(g_lLabelText);++i)
+            {
+                llInstantMessage(kID, llGetScriptName()+" LABEL "+llList2String(g_lLabelText,i));
+            }
         }
     }
 
     timer() {
-        string sText = llGetSubString(g_sScrollText, g_iSctollPos, -1);
-        integer iCharPosition;
-        for(iCharPosition=0; iCharPosition < g_iCharLimit; iCharPosition++)
-            RenderString(iCharPosition, llGetSubString(sText, iCharPosition, iCharPosition));
-        g_iSctollPos++;
-        if(g_iSctollPos > llStringLength(g_sScrollText)) g_iSctollPos = 0 ;
+    
+        integer i;
+        for (i=0; i<llGetListLength(g_lScrollText);++i)
+        {
+            integer iLineScroll = llList2Integer(g_lScrollPos,i);
+            string sText = llGetSubString(llList2String(g_lScrollText,i), iLineScroll, -1);
+            integer iCharPosition;
+            for(iCharPosition=0; iCharPosition < llList2Integer(g_lCharLimit,i); iCharPosition++)
+                RenderString(iCharPosition, llGetSubString(sText, iCharPosition, iCharPosition),i);
+            g_lScrollPos = llListReplaceList(g_lScrollPos,[iLineScroll+1],i,i);
+            
+            if(llList2Integer(g_lScrollPos,i) > llStringLength(llList2String(g_lScrollText,i))) g_lScrollPos = llListReplaceList(g_lScrollPos,[0],i,i);
+        }
     }
 
     changed(integer iChange) {


### PR DESCRIPTION
Creators can setup more than one line of the label. Users then can set the text of each line individually.