### PR TITLE
oc_relay: remoutfit w/o part;   oc_sys: small optimization

### DIFF
--- a/src/collar/oc_label.lsl
+++ b/src/collar/oc_label.lsl
@@ -205,7 +205,7 @@ integer LabelsCount() {
 
     //find all 'Label' prims and count it's
     for(iLink=2; iLink <= iLinkCount; iLink++) {
-        sLabel = llList2String(llGetLinkPrimitiveParams(iLink,[PRIM_NAME]),0);
+        sLabel = llGetLinkName(iLink);
         lTmp = llParseString2List(sLabel, ["~"],[]);
         sLabel = llList2String(lTmp,0);
         if(sLabel == "Label") {
@@ -217,7 +217,7 @@ integer LabelsCount() {
     g_iCharLimit = llGetListLength(g_lLabelLinks);
     //find all 'Label' prims and store it's links to list
     for(iLink=2; iLink <= iLinkCount; iLink++) {
-        sLabel = llList2String(llGetLinkPrimitiveParams(iLink,[PRIM_NAME]),0);
+        sLabel = llGetLinkName(iLink);
         lTmp = llParseString2List(sLabel, ["~"],[]);
         sLabel = llList2String(lTmp,0);
         if(sLabel == "Label") {

--- a/src/collar/oc_meshlabel.lsl
+++ b/src/collar/oc_meshlabel.lsl
@@ -172,7 +172,7 @@ integer LabelsCount() {
     integer iLinkCount = llGetNumberOfPrims();
     //find all 'Label' prims and count it's
     for(iLink=2; iLink <= iLinkCount; iLink++) {
-        lTmp = llParseString2List(llList2String(llGetLinkPrimitiveParams(iLink,[PRIM_NAME]),0), ["~"],[]);
+        lTmp = llParseString2List(llGetLinkName(iLink), ["~"],[]);
         sLabel = llList2String(lTmp,0);
         if(sLabel == "MeshLabel") {
             integer iLine = 0;
@@ -214,7 +214,7 @@ integer LabelsCount() {
         }
         //find all 'Label' prims and store it's links to list
         for(iLink=2; iLink <= iLinkCount; iLink++) {
-            lTmp = llParseString2List(llList2String(llGetLinkPrimitiveParams(iLink,[PRIM_NAME]),0), ["~"],[]);
+            lTmp = llParseString2List(llGetLinkName(iLink), ["~"],[]);
             sLabel = llList2String(lTmp,0);
             if (sLabel == "MeshLabel") {
                 integer iLabel = (integer)llList2String(lTmp,1);

--- a/src/collar/oc_particle.lsl
+++ b/src/collar/oc_particle.lsl
@@ -134,7 +134,7 @@ FindLinkedPrims() {
     integer linkcount = llGetNumberOfPrims();
     //root prim is 1, so start at 2
     for (g_iLoop = 2; g_iLoop <= linkcount; g_iLoop++) {
-        string sPrimDesc = (string)llGetObjectDetails(llGetLinkKey(g_iLoop), [OBJECT_DESC]);
+        string sPrimDesc = (string)llGetLinkPrimitiveParams((g_iLoop), [PRIM_DESC]);
         list lTemp = llParseString2List(sPrimDesc, ["~"], []);
         integer iLoop;
         for (iLoop = 0; iLoop < llGetListLength(lTemp); iLoop++) {

--- a/src/collar/oc_relay.lsl
+++ b/src/collar/oc_relay.lsl
@@ -300,7 +300,13 @@ string HandleCommand(string sIdent, key kID, string sCom, integer iAuthed) {
             string sBehav=llGetSubString(llList2String(lSubArgs,0),1,-1);
             list lTemp=llParseString2List(sBehav,[":"],[]);
             if (g_iSmartStrip && llList2String(lTemp,0) == "remoutfit" && sVal == "force")
-                sBehav = "detachallthis:" + llList2String(lTemp,1);
+                if (llList2String(lTemp,1) != "") sBehav = "detachallthis:" + llList2String(lTemp,1);
+                else {  // only if  'remoutfit=force'
+                    list parts=["jacket","pants","shirt","shoes","skirt","socks","underpants","undershirt"]; //"gloves","alpha","tattoo","physics"];
+                    integer n;
+                    for (n=0; n<llGetListLength(parts); ++n)
+                        llMessageLinked(LINK_RLV,RLV_CMD,"detachallthis:"+llList2String(parts,n)+"=force",kID);
+                }
             if (sVal=="force"||sVal=="n"||sVal=="add"||sVal=="y"||sVal=="rem"||sBehav=="clear")
                 llMessageLinked(LINK_RLV,RLV_CMD,sBehav+"="+sVal,kID);
             else sAck="ko";

--- a/src/collar/oc_relay.lsl
+++ b/src/collar/oc_relay.lsl
@@ -299,7 +299,7 @@ string HandleCommand(string sIdent, key kID, string sCom, integer iAuthed) {
         } else if ((lSubArgs!=[])==2) {
             string sBehav=llGetSubString(llList2String(lSubArgs,0),1,-1);
             list lTemp=llParseString2List(sBehav,[":"],[]);
-            if (g_iSmartStrip && llList2String(lTemp,0) == "remoutfit" && sVal == "force")
+            if (g_iSmartStrip && llList2String(lTemp,0) == "remoutfit" && sVal == "force") {
                 if (llList2String(lTemp,1) != "") sBehav = "detachallthis:" + llList2String(lTemp,1);
                 else {  // only if  'remoutfit=force'
                     list parts=["jacket","pants","shirt","shoes","skirt","socks","underpants","undershirt"]; //"gloves","alpha","tattoo","physics"];
@@ -307,6 +307,7 @@ string HandleCommand(string sIdent, key kID, string sCom, integer iAuthed) {
                     for (n=0; n<llGetListLength(parts); ++n)
                         llMessageLinked(LINK_RLV,RLV_CMD,"detachallthis:"+llList2String(parts,n)+"=force",kID);
                 }
+            }
             if (sVal=="force"||sVal=="n"||sVal=="add"||sVal=="y"||sVal=="rem"||sBehav=="clear")
                 llMessageLinked(LINK_RLV,RLV_CMD,sBehav+"="+sVal,kID);
             else sAck="ko";

--- a/src/collar/oc_relay.lsl
+++ b/src/collar/oc_relay.lsl
@@ -300,12 +300,12 @@ string HandleCommand(string sIdent, key kID, string sCom, integer iAuthed) {
             string sBehav=llGetSubString(llList2String(lSubArgs,0),1,-1);
             list lTemp=llParseString2List(sBehav,[":"],[]);
             if (g_iSmartStrip && llList2String(lTemp,0) == "remoutfit" && sVal == "force") {
-                if (llList2String(lTemp,1) != "") sBehav = "detachallthis:" + llList2String(lTemp,1);
+                if (llList2String(lTemp,1) != "") llMessageLinked(LINK_RLV,RLV_CMD,"detachallthis:"+llList2String(lTemp,1)+"="+sVal,kID);
                 else {  // only if  'remoutfit=force'
                     list parts=["jacket","pants","shirt","shoes","skirt","socks","underpants","undershirt"]; //"gloves","alpha","tattoo","physics"];
                     integer n;
                     for (n=0; n<llGetListLength(parts); ++n)
-                        llMessageLinked(LINK_RLV,RLV_CMD,"detachallthis:"+llList2String(parts,n)+"=force",kID);
+                        llMessageLinked(LINK_RLV,RLV_CMD,"detachallthis:"+llList2String(parts,n)+"="+sVal,kID);
                 }
             }
             if (sVal=="force"||sVal=="n"||sVal=="add"||sVal=="y"||sVal=="rem"||sBehav=="clear")

--- a/src/collar/oc_rlvsuite.lsl
+++ b/src/collar/oc_rlvsuite.lsl
@@ -1,7 +1,7 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2014 - 2017 Wendy Starfall, littlemousy, Sumi Perl,    
-// Garvin Twine, Romka Swallowtail et al.   
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2014 - 2017 Wendy Starfall, littlemousy, Sumi Perl,
+// Garvin Twine, Romka Swallowtail et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 string g_sScriptVersion = "7.3";
 //menu setup
@@ -190,7 +190,7 @@ DoTerminalCommand(string sMessage, key kID) {
     string sCRLF= llUnescapeURL("%0A");
     list lCommands = llParseString2List(sMessage, [sCRLF], []);
     sMessage = llDumpList2String(lCommands, ",");
-    
+
     llMessageLinked(LINK_RLV,RLV_CMD,sMessage,"Terminal");
     llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Your command(s) were sent to %WEARERNAME%'s Viewer:\n" + sMessage, kID);
     llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"secondlife:///app/agent/"+(string)kID+"/about" + " has changed your rlv restrictions.", g_kWearer);
@@ -247,7 +247,7 @@ DetachMenu(key kID, integer iAuth)
     list attachmentKeys = llGetAttachedList(llGetOwner());
     integer n;
     integer iStop = llGetListLength(attachmentKeys);
-    
+
     for (n = 0; n < iStop; n++) {
         key k = llList2Key(attachmentKeys, n);
         if (k != llGetKey()) {
@@ -257,7 +257,7 @@ DetachMenu(key kID, integer iAuth)
 
     list lButtons;
     iStop = llGetListLength(g_lAttachments);
-    
+
     for (n = 0; n < iStop; n+=2) {
         lButtons += [llList2String(g_lAttachments, n)];
     }
@@ -368,15 +368,15 @@ UserCommand(integer iNum, string sStr, key kID, integer bFromMenu) {
         return;
     }
     //restrictions command handling
-    
-    
-    
+
+
+
     integer iNoAccess=FALSE;
     if (sStr == TERMINAL_CHAT_COMMAND || sStr == "menu " + TERMINAL_BUTTON) {
-        
+
         /// g_iTerminalAccess as of v7.2 will define the access rights for the terminal.
         // A flag is set if denied.
-        if((g_iTerminalAccess&1) && iNum ==CMD_WEARER) { 
+        if((g_iTerminalAccess&1) && iNum ==CMD_WEARER) {
             iNoAccess=TRUE;
             return;
         }else if((g_iTerminalAccess&2) && iNum == CMD_TRUSTED){
@@ -389,22 +389,22 @@ UserCommand(integer iNum, string sStr, key kID, integer bFromMenu) {
             iNoAccess=TRUE;
             return;
         }
-        
+
         // CMD_OWNER is never denied terminal. CMD_OWNER is the access level of the owner level as well as the unowned or selfowned wearer.
-        
+
         if (sStr == TERMINAL_CHAT_COMMAND) g_iMenuCommand = FALSE;
         else g_iMenuCommand = TRUE;
-        
+
         string sAppendSettings = "Wearer blocked: "+bool2string((g_iTerminalAccess&1))+"\nTrusted blocked: "+bool2string((g_iTerminalAccess&2))+"\nPublic blocked: "+bool2string((g_iTerminalAccess&4))+"\nGroup blocked: "+bool2string((g_iTerminalAccess&8))+"\n\nFor help configuring, type 'help' without the quotes!\nTo exit the terminal, simply type 'back'";
-        
+
         Dialog(kID, g_sTerminalText+"\n"+sAppendSettings, [], [], 0, iNum, "terminal");
         return;
     } else if(sStr == RESTRICTIONS_CHAT_COMMAND || sStr == "menu "+RESTRICTION_BUTTON){
         RestrictionsMenu(kID, iNum);
         return;
     }
-    
-    
+
+
     if (sLowerStr == "restrictions back") {
         llMessageLinked(LINK_RLV, iNum, "menu " + COLLAR_PARENT_MENU, kID);
         return;
@@ -623,9 +623,9 @@ UserCommand(integer iNum, string sStr, key kID, integer bFromMenu) {
     } else if (!llSubStringIndex(sLowerStr, "hudtpto:") && (iNum == CMD_OWNER || iNum == CMD_TRUSTED)) {
         if (g_iRLVOn) llMessageLinked(LINK_RLV,RLV_CMD,llGetSubString(sLowerStr,3,-1),"");
     } else if (sLowerStr == "menu detach" || sLowerStr == "detach") {
-        DetachMenu(kID, iNum); 
+        DetachMenu(kID, iNum);
     }
-    
+
     if(iNoAccess)llMessageLinked(LINK_DIALOG,NOTIFY, "0%NOACCESS%", kID);
     if (bFromMenu) RestrictionsMenu(kID,iNum);
 }
@@ -635,7 +635,7 @@ default {
     state_entry() {
         g_kWearer = llGetOwner();
         //Debug("Starting");
-        string R="restrictions";
+        string R="restrictions_";
         list tokens = [R+"send",R+"read", R+"hear", R+"talk",R+"touch",R+"stray", R+"stand",R+"rummage", R+"blurred", R+"dazed", "terminal_accessbitset"];
         integer i=0;
         integer end=llGetListLength(tokens);
@@ -730,7 +730,7 @@ default {
                     UserCommand(iAuth, "menu force sit", kAv, TRUE);
                 } else if (sMenu == "find") UserCommand(iAuth, "sit "+sMessage, kAv, FALSE);
                 else if (sMenu == "terminal") {
-                    
+
                     if(iAuth == CMD_OWNER ){
                         list tmp = llParseString2List(llToLower(sMessage), [" "],[]);
                         integer iTerminate=FALSE;
@@ -741,7 +741,7 @@ default {
                             if(llList2String(tmp,1) == "trusted" && (g_iTerminalAccess&2))iAddAccess=2;
                             if(llList2String(tmp,1) == "public" && (g_iTerminalAccess&4))iAddAccess=4;
                             if(llList2String(tmp,1) == "group" && (g_iTerminalAccess&8))iAddAccess=8;
-                            
+
                             g_iTerminalAccess=(g_iTerminalAccess-iAddAccess);
                         } else if(llList2String(tmp,0)=="deny"){
                             integer iRemAccess;
@@ -750,7 +750,7 @@ default {
                             if(llList2String(tmp,1) == "trusted" && !(g_iTerminalAccess&2))iRemAccess=2;
                             if(llList2String(tmp,1) == "public" && !(g_iTerminalAccess&4))iRemAccess=4;
                             if(llList2String(tmp,1) == "group" && !(g_iTerminalAccess&8))iRemAccess=8;
-                            
+
                             g_iTerminalAccess=(g_iTerminalAccess+iRemAccess);
                         }else if(llList2String(tmp,0)=="help"){
                             iTerminate=TRUE;
@@ -761,13 +761,13 @@ default {
                         }
                         if(iTerminate){
                             llMessageLinked(LINK_SAVE, LM_SETTING_SAVE, "terminal_accessbitset="+(string)g_iTerminalAccess,"");
-                            llMessageLinked(LINK_SET, iAuth, "menu Terminal", kAv); 
+                            llMessageLinked(LINK_SET, iAuth, "menu Terminal", kAv);
                             return; // this is not a RLV command. We're safe to exit here.
                         }// if it was NOT a config command, then process as a RLV command.
                     }
-                    
-                    
-                    
+
+
+
                     if (llStringLength(sMessage) > 4) DoTerminalCommand(sMessage, kAv);
                     llMessageLinked(LINK_SET, iAuth, "menu Terminal", kAv);
                 } else if (sMenu == "folder" || sMenu == "multimatch") {
@@ -794,7 +794,7 @@ default {
                 } else if (sMenu == "detach") {
                     if (sMessage == UPMENU) {
                         llMessageLinked(LINK_RLV, iAuth, "menu "+COLLAR_PARENT_MENU, kAv);
-                    } else {              
+                    } else {
                         integer idx = llListFindList(g_lAttachments, [sMessage]);
                         if (~idx) {
                             string uuid = llList2String(g_lAttachments, idx + 1);

--- a/src/collar/oc_rlvsys.lsl
+++ b/src/collar/oc_rlvsys.lsl
@@ -1,8 +1,8 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2008 - 2016 Satomi Ahn, Nandana Singh, Wendy Starfall,  
-// Medea Destiny, littlemousy, Romka Swallowtail, Garvin Twine,      
-// Sumi Perl et al.     
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2008 - 2016 Satomi Ahn, Nandana Singh, Wendy Starfall,
+// Medea Destiny, littlemousy, Romka Swallowtail, Garvin Twine,
+// Sumi Perl et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 string g_sScriptVersion = "7.3";
 integer g_iRLVOn = TRUE;
@@ -478,7 +478,7 @@ default {
             llSetRemoteScriptAccessPin(iPin);
             llMessageLinked(iSender, LOADPIN, (string)iPin+"@"+llGetScriptName(),llGetKey());
         }
-        else if (iNum == REBOOT && sStr == "reboot") llResetScript(); 
+        else if (iNum == REBOOT && sStr == "reboot") llResetScript();
         else if (iNum == LINK_UPDATE) {
             if (sStr == "LINK_DIALOG") LINK_DIALOG = iSender;
             else if (sStr == "LINK_SAVE") {
@@ -487,6 +487,7 @@ default {
             } else if (sStr == "LINK_REQUEST") llMessageLinked(LINK_ALL_OTHERS,LINK_UPDATE,"LINK_RLV","");
         } else if (g_iRlvActive) {
             llSetLinkPrimitiveParams(LINK_THIS,[PRIM_FULLBRIGHT,ALL_SIDES,TRUE,PRIM_BUMP_SHINY,ALL_SIDES,PRIM_SHINY_NONE,PRIM_BUMP_NONE,PRIM_GLOW,ALL_SIDES,0.4]);
+            llSensorRepeat("N0thin9","abc",ACTIVE,0.1,0.1,0.22);
             if (iNum == RLV_CMD) {
                 //Debug("Received RLV_CMD: "+sStr+" from "+(string)kID);
                 list lCommands=llParseString2List(llToLower(sStr),[","],[]);
@@ -558,7 +559,7 @@ default {
                 }
             }
         }
-        
+
         if(iNum == LINK_CMD_DEBUG){
             integer onlyver=0;
             if(sStr == "ver")onlyver=1;
@@ -567,13 +568,14 @@ default {
             // The rest of this command can be access by <prefix> debug
             llInstantMessage(kID, llGetScriptName() +" FREE MEMORY: "+(string)llGetFreeMemory()+" bytes");
             llInstantMessage(kID, llGetScriptName()+" RLV_ON: "+(string)g_iRLVOn);
-            
-            
-            
         }
     }
-    
-    
+
+    no_sensor() {
+        llSetLinkPrimitiveParamsFast(LINK_THIS,[PRIM_FULLBRIGHT,ALL_SIDES,FALSE,PRIM_BUMP_SHINY,ALL_SIDES,PRIM_SHINY_HIGH,PRIM_BUMP_NONE,PRIM_GLOW,ALL_SIDES,0.0]);
+        llSensorRemove();
+    }
+
     timer() {
         if (g_iWaitRelay) {
             if (g_iWaitRelay < 2) {

--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -705,8 +705,6 @@ default {
             llInstantMessage(kID, llGetScriptName()+" LOCKED: "+(string)g_iLocked);
             llInstantMessage(kID, llGetScriptName()+" HIDDEN: "+(string)g_iHide);
             llInstantMessage(kID, llGetScriptName()+" DETACHED WHILE LOCKED: "+(string)g_bDetached);
-            
-            
         }
     }
 
@@ -720,14 +718,13 @@ default {
             g_iWaitRebuild = TRUE;
             PermsCheck();
             llSetTimerEvent(1.0);
-            llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST,"ALL","");
             if(llGetInventoryType(".settings") == INVENTORY_NOTECARD){
                 if(llGetInventoryKey(".settings") != g_kExistingSettings){
                     g_iSettingsReader=0;
                     g_kSettingsReader = llGetNotecardLine(".settings", g_iSettingsReader);
                     g_kExistingSettings = llGetInventoryKey(".settings");
                 }
-            }
+            } else llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST,"ALL","");
             if(llGetInventoryNumber(INVENTORY_ANIMATION)!=0){
                 AnnounceAnimInventory(LINK_ALL_OTHERS);
             }
@@ -754,10 +751,10 @@ default {
     
     dataserver(key kID, string sData){
         if(kID==g_kSettingsReader){
-            if(sData ==EOF)llMessageLinked(LINK_SET,LM_SETTING_REQUEST,"ALL","");
+            if(sData ==EOF)llMessageLinked(LINK_SAVE,LM_SETTING_REQUEST,"ALL","");
             else{
                 g_iSettingsReader++;
-                llMessageLinked(LINK_SET, LM_SETTING_RELAY_CONTENT, sData, (string)g_iSettingsReader);
+                llMessageLinked(LINK_SAVE, LM_SETTING_RELAY_CONTENT, sData, (string)g_iSettingsReader);
                 g_kSettingsReader=llGetNotecardLine(".settings", g_iSettingsReader);
             }
         }

--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -724,7 +724,7 @@ default {
                     g_kSettingsReader = llGetNotecardLine(".settings", g_iSettingsReader);
                     g_kExistingSettings = llGetInventoryKey(".settings");
                 }
-            } else llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST,"ALL","");
+            } else llMessageLinked(LINK_SAVE, LM_SETTING_REQUEST,"ALL","");
             if(llGetInventoryNumber(INVENTORY_ANIMATION)!=0){
                 AnnounceAnimInventory(LINK_ALL_OTHERS);
             }


### PR DESCRIPTION
**oc_relay:**
fix smart detach problem when a command 'remoutfit' is received without specifying part:  remoutfit=force
because 'detachallthis:' don't work without specifying part: 'detachallthis:=force'

**oc_sys:**
reading .settings notecard:
1 - do LM_SETTING_REQUEST,"ALL" only if card not found
2 - no need to spam data to all LINK_SET, send only to LINK_SAVE