### PR TITLE
Updated limits for owners, oc_settings

### DIFF
--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -237,9 +237,9 @@ LoadSetting(string sData, integer iLine) {
                         list lOut;
                         integer n;
                         do {//sanity check for valid entries
-                            if (llList2Key(lTest,n)) //if this is not a valid key, it's useless
+                            if (llList2Key(lTest,n)) { //if this is not a valid key, it's useless
                                 lOut += llList2String(lTest,n);
-                            integer iTest = llGetListLength(lOut);
+                            }
                         } while (++n < llGetListLength(lTest));
                         sValue = llDumpList2String(lOut,",");
                         lTest = [];

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -240,11 +240,7 @@ LoadSetting(string sData, integer iLine) {
                             if (llList2Key(lTest,n)) //if this is not a valid key, it's useless
                                 lOut += llList2String(lTest,n);
                             integer iTest = llGetListLength(lOut);
-                            if (sToken == "owner" &&  iTest == 3)  jump next;
-                            else if (sToken == "trust" &&  iTest == 15)  jump next;
-                            else if (sToken == "block" &&  iTest == 9)  jump next;
                         } while (++n < llGetListLength(lTest));
-                        @next;
                         sValue = llDumpList2String(lOut,",");
                         lTest = [];
                         lOut = [];


### PR DESCRIPTION
Suggested update for the limits in the oc_settings script in order to get away from the extremely limiting limits that were set 4 years ago.
As it was before, only 3 primary owners could be added from settings notecard, only 15 trusted and only 9 blocked.
This is despite the auth script allowing 28 of any combination of these added.
If you add 10 owners to your collar and then press to save your settings and put them into the settings notecard, you'll only receive 3 of them and the save won't have worked as you expected.
Removing the limits makes the saving and loading work as you expect.
There is indeed a risk that you may send too many users to the auth script and potentially crash it in case the auth script doesn't handle that. But this is only possible if you manually add users to the notecard yourself, without using the Print feature.
However, auth should be the one handling its own memory, settings shouldn't handle auth's memory for it.