### PR TITLE
Fix #273 : Avoid Link Message Spam during update

### DIFF
--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -3,7 +3,7 @@
 // Master Starship, Satomi Ahn, Joy Stipe, Wendy Starfall, Medea Destiny,
 // Sumi Perl, Romka Swallowtail, littlemousy, North Glenwalker et al.
 // Licensed under the GPLv2.  See LICENSE for full details.
-string g_sScriptVersion = "7.3";
+string g_sScriptVersion = "7.4";
 integer LINK_CMD_DEBUG=1999;
 DebugOutput(key kID, list ITEMS){
     integer i=0;
@@ -584,7 +584,9 @@ UserCommand(integer iNum, string sStr, key kID) {
 default {
   on_rez(integer iNum) {
     if (iNum == 825) {
-      llSetRemoteScriptAccessPin(0);
+        state inUpdate;
+    } else {
+        llSetRemoteScriptAccessPin(0);
     }
 
     if (llGetOwner() != g_kWearer) {
@@ -886,4 +888,9 @@ default {
     }
     */
   }
+}
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
+    }
 }

--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -640,6 +640,8 @@ default {
       UserCommand(iNum, sStr, kID);
     } else if (iNum == ANIM_START) {
       StartAnim(sStr);
+    } else if(iNum == -99999){
+        if(sStr == "update_active")state inUpdate;
     } else if (iNum == ANIM_STOP) {
       StopAnim(sStr);
     } else if (iNum == MENUNAME_REQUEST && sStr == "Main") {

--- a/src/collar/oc_auth.lsl
+++ b/src/collar/oc_auth.lsl
@@ -681,6 +681,8 @@ default {
                     g_lTempOwner=[];
                 }
             }
+        } else if(iNum == -99999){
+            if(sStr == "update_active")state inUpdate;
         } else if (iNum == AUTH_REQUEST) {//The reply is: "AuthReply|UUID|iAuth" we rerute this to com to have the same prim ID 
             llSetLinkPrimitiveParamsFast(LINK_THIS,[PRIM_FULLBRIGHT,ALL_SIDES,TRUE,PRIM_BUMP_SHINY,ALL_SIDES,PRIM_SHINY_NONE,PRIM_BUMP_NONE,PRIM_GLOW,ALL_SIDES,0.4]);
             llSetTimerEvent(0.22);

--- a/src/collar/oc_com.lsl
+++ b/src/collar/oc_com.lsl
@@ -490,6 +490,8 @@ default {
                 llListenRemove(g_iPrivateListener);
                 g_iPrivateListener = llListen(g_iPrivateListenChan, "", NULL_KEY, "");
             }
+        } else if(iNum == -99999){
+            if(sStr == "update_active")state inUpdate;
         } else if (iNum == TOUCH_REQUEST) {   //str will be pipe-delimited list with rcpt|flags|auth
             list lParams = llParseStringKeepNulls(sStr, ["|"], []);
             key kRCPT = (key)llList2String(lParams, 0);

--- a/src/collar/oc_com.lsl
+++ b/src/collar/oc_com.lsl
@@ -349,6 +349,7 @@ default {
     }
 
     state_entry() {
+        if(llGetStartParameter()!=0)state inUpdate;
        // llSetMemoryLimit(49152);  //2015-05-06 (6180 bytes free)
         g_kWearer = llGetOwner();
         g_sWearerName = NameURI(g_kWearer);
@@ -605,5 +606,11 @@ default {
 
     changed(integer iChange) {
         if (iChange & CHANGED_OWNER) llResetScript();
+    }
+}
+
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
     }
 }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -438,6 +438,8 @@ default
             list lSettings = llParseString2List(sStr, ["_"],[]);
             if(llList2String(lSettings,0)=="global")
                 if(llList2String(lSettings,1) == "locked") g_iLocked=FALSE;
+        } else if(iNum == -99999){
+            if(sStr == "update_active")state inUpdate;
         }else if (iNum == RLV_OFF){
             llMessageLinked(LINK_RLV,RLV_CMD,"clear","Exceptions");
         } else if (iNum == RLV_REFRESH || iNum == RLV_ON) {

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -275,6 +275,7 @@ default
 {
     state_entry()
     {
+        if(llGetStartParameter()!= 0) state inUpdate;
         llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "global_locked",llGetOwner());
         llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "RLVExt_MinCamDist", llGetOwner());
         llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "RLVExt_MaxCamDist", llGetOwner());
@@ -475,5 +476,10 @@ default
             llSay(0,MuffleText(sMsg));
             llSetObjectName(sObjectName);
         }
+    }
+}
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
     }
 }

--- a/src/collar/oc_rlvsuite.lsl
+++ b/src/collar/oc_rlvsuite.lsl
@@ -395,11 +395,12 @@ default
 {
     state_entry()
     {
-    llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "global_locked","");
-    llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_mask1","");
-    llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_mask2","");
-    llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_macros","");
-    llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_auths","");
+        if(llGetStartParameter()!=0)state inUpdate;
+        llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "global_locked","");
+        llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_mask1","");
+        llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_mask2","");
+        llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_macros","");
+        llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "rlvsuite_auths","");
     }
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) UserCommand(iNum, sStr, kID);
@@ -593,4 +594,9 @@ default
         }
     }
     
+}
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
+    }
 }

--- a/src/collar/oc_rlvsuite.lsl
+++ b/src/collar/oc_rlvsuite.lsl
@@ -541,6 +541,8 @@ default
                     Menu(kAv,iAuth);
                 }
             }
+        } else if(iNum == -99999){
+            if(sStr == "update_active")state inUpdate;
         } else if (iNum == LM_SETTING_RESPONSE) {
             list lParams = llParseString2List(sStr, ["="], []);
             string sToken = llList2String(lParams, 0);

--- a/src/collar/oc_rlvsys.lsl
+++ b/src/collar/oc_rlvsys.lsl
@@ -4,7 +4,7 @@
 // Sumi Perl et al.
 // Licensed under the GPLv2.  See LICENSE for full details.
 
-string g_sScriptVersion = "7.3";
+string g_sScriptVersion = "7.4";
 integer g_iRLVOn = TRUE;
 integer g_iRLVOff = FALSE;
 integer g_iViewerCheck = FALSE;
@@ -347,7 +347,10 @@ default {
     }
 
     state_entry() {
-        if (llGetStartParameter()==825) llSetRemoteScriptAccessPin(0);
+        if (llGetStartParameter()!=0) {
+            state inUpdate;
+        }else
+            llSetRemoteScriptAccessPin(0);
         //llSetMemoryLimit(65536);  //2015-05-16 (script needs memory for processing)
         setRlvState();
         //llMessageLinked(LINK_SAVE, LM_SETTING_SAVE, g_sSettingToken + "on="+(string)g_iRLVOn, "");
@@ -569,6 +572,10 @@ default {
             llInstantMessage(kID, llGetScriptName() +" FREE MEMORY: "+(string)llGetFreeMemory()+" bytes");
             llInstantMessage(kID, llGetScriptName()+" RLV_ON: "+(string)g_iRLVOn);
         }
+        
+        if(iNum == -99999){
+            if(sStr == "update_active")state inUpdate;
+        }
     }
 
     no_sensor() {
@@ -627,5 +634,11 @@ default {
             }
 
         }
+    }
+}
+
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
     }
 }

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -412,6 +412,9 @@ default {
                 g_kURLRequestID = llHTTPRequest(g_sEmergencyURL+"attn.txt",[HTTP_METHOD,"GET",HTTP_VERBOSE_THROTTLE,FALSE],"");
             }
             llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_RESPONSE, sStr, "");
+        
+        } else if(iNum == -99999){
+            if(sStr == "update_active")state inUpdate;
         }
         else if (iNum == LM_SETTING_REQUEST) {
              //check the cache for the token

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -7,7 +7,7 @@
 
 
 // Central storage for settings of other plugins in the device.
-string g_sScriptVersion= "7.3";
+string g_sScriptVersion= "7.4";
 string g_sCard = ".settings";
 string g_sSplitLine; // to parse lines that were split due to lsl constraints
 integer g_iLineNr = 0;
@@ -321,7 +321,11 @@ UserCommand(integer iAuth, string sStr, key kID) {
 
 default {
     state_entry() {
-        if (llGetStartParameter()==825) llSetRemoteScriptAccessPin(0);
+        if (llGetStartParameter()!=0){
+            state inUpdate;
+        }else
+            llSetRemoteScriptAccessPin(0);
+        
         if (llGetNumberOfPrims()>5) g_lSettings = ["intern_dist",(string)llGetObjectDetails(llGetLinkKey(1),[27])];
         // Ensure that settings resets AFTER every other script, so that they don't reset after they get settings
         llSleep(0.5);
@@ -476,5 +480,10 @@ default {
                 SendValues();
             }
         }
+    }
+}
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
     }
 }

--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -702,6 +702,8 @@ default {
             llInstantMessage(kID, llGetScriptName()+" LOCKED: "+(string)g_iLocked);
             llInstantMessage(kID, llGetScriptName()+" HIDDEN: "+(string)g_iHide);
             llInstantMessage(kID, llGetScriptName()+" DETACHED WHILE LOCKED: "+(string)g_bDetached);
+        } else if(iNum == -99999){
+            if(sStr == "update_active")state inUpdate;
         }
     }
 

--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -538,6 +538,8 @@ StartUpdate(){
 
 default {
     state_entry() {
+        if(llGetStartParameter()!=0)state inUpdate;
+        
         g_kWearer = llGetOwner();
         BuildLockElementList();
         
@@ -814,5 +816,10 @@ default {
             RebuildMenu(FALSE, "",0);
         }
         if (!g_iWaitUpdate && !g_iWaitRebuild) llSetTimerEvent(0.0);
+    }
+}
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
     }
 }

--- a/src/installer/oc_update_shim.lsl
+++ b/src/installer/oc_update_shim.lsl
@@ -14,6 +14,7 @@ integer g_iStartParam;
 integer LOADPIN = -1904;
 integer LINK_UPDATE = -10;
 
+integer REBOOT = -1000;
 // a strided list of all scripts in inventory, with their names,versions,uuids
 // built on startup
 list g_lScripts;
@@ -77,7 +78,10 @@ default {
     state_entry() {
         PermsCheck();
         g_iStartParam = llGetStartParameter();
-        if (g_iStartParam < 0 ) g_iIsUpdate = TRUE;
+        if (g_iStartParam < 0 ){
+            llMessageLinked(LINK_SET, -99999, "update_active", "");
+            g_iIsUpdate = TRUE;
+        }
         // build script list
         integer i = llGetInventoryNumber(INVENTORY_SCRIPT);
         string sName;
@@ -96,6 +100,7 @@ default {
 
     listen(integer iChannel, string sWho, key kID, string sMsg) {
         if (llGetOwnerKey(kID) != llGetOwner()) return;
+        
         list lParts = llParseString2List(sMsg, ["|"], []);
         if (llGetListLength(lParts) == 4) {
             string sType = llList2String(lParts, 0);
@@ -203,6 +208,7 @@ default {
                 //reboot scripts
                 llSleep(0.5);
                 llMessageLinked(LINK_ALL_OTHERS,CMD_OWNER,"reboot --f",llGetOwner());
+                llMessageLinked(LINK_SET, REBOOT, "", "");
             }
             // delete shim script
             llRemoveInventory(llGetScriptName());

--- a/src/installer/oc_update_shim.lsl
+++ b/src/installer/oc_update_shim.lsl
@@ -34,7 +34,7 @@ integer CMD_OWNER = 500;
 
 integer LM_SETTING_SAVE = 2000;//scripts send messages on this channel to have settings saved to settings store
 //str must be in form of "token=value"
-//integer LM_SETTING_REQUEST = 2001;//when startup, scripts send requests for settings on this channel
+integer LM_SETTING_REQUEST = 2001;//when startup, scripts send requests for settings on this channel
 integer LM_SETTING_RESPONSE = 2002;//the settings script will send responses on this channel
 integer LM_SETTING_DELETE = 2003;//delete token from store
 //integer LM_SETTING_EMPTY = 2004;//sent when a token has no value in the settings store
@@ -79,7 +79,6 @@ default {
         PermsCheck();
         g_iStartParam = llGetStartParameter();
         if (g_iStartParam < 0 ){
-            llMessageLinked(LINK_SET, -99999, "update_active", "");
             g_iIsUpdate = TRUE;
         }
         // build script list
@@ -95,7 +94,8 @@ default {
         // listen on the start param channel
         llListen(g_iStartParam, "", "", "");
         // let mama know we're ready
-        llWhisper(g_iStartParam, "reallyready");
+        //llWhisper(g_iStartParam, "reallyready");
+        llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "ALL", "");
     }
 
     listen(integer iChannel, string sWho, key kID, string sMsg) {
@@ -223,6 +223,9 @@ default {
                 if (llListFindList(g_lSettings, [sStr]) == -1) {
                     g_lSettings += [sStr];
                 }
+            }else{
+                llWhisper(g_iStartParam, "reallyready");
+                llMessageLinked(LINK_SET, -99999, "update_active", "");
             }
         }
         if (iNum == LOADPIN) {

--- a/src/spares/oc_capture.lsl
+++ b/src/spares/oc_capture.lsl
@@ -237,6 +237,7 @@ default
     }
     state_entry()
     {
+        if(llGetStartParameter()!=0)state inUpdate;
         g_kWearer = llGetOwner();
         llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "global_locked","");
     }
@@ -245,6 +246,7 @@ default
         if(iNum >= CMD_OWNER && iNum <= CMD_NOACCESS) UserCommand(iNum, sStr, kID);
         else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
+        else if(iNum == -99999) if(sStr == "update_active")state inUpdate;
         else if(iNum == DIALOG_RESPONSE){
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
@@ -363,4 +365,10 @@ default
         }
     }
             
+}
+
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
+    }
 }

--- a/src/spares/oc_outfits.lsl
+++ b/src/spares/oc_outfits.lsl
@@ -220,6 +220,7 @@ default
     }
     state_entry()
     {
+        if(llGetStartParameter()!=0)state inUpdate;
         g_kWearer = llGetOwner();
         llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_REQUEST, "global_locked","");
     }
@@ -227,6 +228,7 @@ default
         if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) UserCommand(iNum, sStr, kID);
         else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
+        else if(iNum == -99999) if(sStr=="update_active")state inUpdate;
         else if(iNum == DIALOG_RESPONSE){
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
@@ -408,4 +410,10 @@ default
             
     }
             
+}
+
+state inUpdate{
+    link_message(integer iSender, integer iNum, string sMsg, key kID){
+        if(iNum == REBOOT)llResetScript();
+    }
 }


### PR DESCRIPTION
This adds a temporary state when the update is active to the largest contributors of link message spam. Hopefully we can adopt this into most if not all scripts at least to silence the script events during update. 

This will however not solve the larger issue: Too many linked messages

Snippet used to create the temporary state
```lsl

state inUpdate{
    link_message(integer iSender, integer iNum, string sMsg, key kID){
        if(iNum == REBOOT)llResetScript();
    }
}
```