### PR TITLE
Resolve #54

### DIFF
--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -640,8 +640,6 @@ default {
       UserCommand(iNum, sStr, kID);
     } else if (iNum == ANIM_START) {
       StartAnim(sStr);
-    } else if(iNum == -99999){
-        if(sStr == "update_active")state inUpdate;
     } else if (iNum == ANIM_STOP) {
       StopAnim(sStr);
     } else if (iNum == MENUNAME_REQUEST && sStr == "Main") {

--- a/src/collar/oc_auth.lsl
+++ b/src/collar/oc_auth.lsl
@@ -681,8 +681,6 @@ default {
                     g_lTempOwner=[];
                 }
             }
-        } else if(iNum == -99999){
-            if(sStr == "update_active")state inUpdate;
         } else if (iNum == AUTH_REQUEST) {//The reply is: "AuthReply|UUID|iAuth" we rerute this to com to have the same prim ID 
             llSetLinkPrimitiveParamsFast(LINK_THIS,[PRIM_FULLBRIGHT,ALL_SIDES,TRUE,PRIM_BUMP_SHINY,ALL_SIDES,PRIM_SHINY_NONE,PRIM_BUMP_NONE,PRIM_GLOW,ALL_SIDES,0.4]);
             llSetTimerEvent(0.22);
@@ -734,12 +732,14 @@ default {
                     else if (sMessage == UPMENU) AuthMenu(kAv, iAuth);
                     else if (sMessage == "No") llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"Runaway aborted.",kAv);
                 } if (llSubStringIndex(sMenu,"AddAvi") == 0) {
-                    if ((key)sMessage)
-                        AddUniquePerson(sMessage, llGetSubString(sMenu,6,-1), kAv); //should be safe to uase key2name here, as we added from sensor dialog
+                    if(sMessage == ">Wearer<")
+                        AddUniquePerson( llGetOwner(), llGetSubString(sMenu,6,-1),kAv); // add the wearer
                     else if (sMessage == "BACK")
                         AuthMenu(kAv,iAuth);
-                    else if(sMessage == ">Wearer<")
-                        AddUniquePerson(sMessage, llGetOwner(), kAv);
+                    else if ((key)sMessage)
+                        AddUniquePerson(sMessage, llGetSubString(sMenu,6,-1), kAv); //should be safe to uase key2name here, as we added from sensor dialog
+                    
+                    
                 }
             }
             

--- a/src/collar/oc_rlvsys.lsl
+++ b/src/collar/oc_rlvsys.lsl
@@ -573,9 +573,6 @@ default {
             llInstantMessage(kID, llGetScriptName()+" RLV_ON: "+(string)g_iRLVOn);
         }
         
-        if(iNum == -99999){
-            if(sStr == "update_active")state inUpdate;
-        }
     }
 
     no_sensor() {

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -413,8 +413,6 @@ default {
             }
             llMessageLinked(LINK_ALL_OTHERS, LM_SETTING_RESPONSE, sStr, "");
         
-        } else if(iNum == -99999){
-            if(sStr == "update_active")state inUpdate;
         }
         else if (iNum == LM_SETTING_REQUEST) {
              //check the cache for the token


### PR DESCRIPTION
Removes the OwnSelf button and allows the wearer to be added by either the Trust or the Owner buttons. This allows the wearer to be added to any access level except for Block for obvious reasons.

If we were to allow block, it would also block other features such as the safeword. This feature can be reverted easily if needed in the future. 