### PR TITLE
Fix Safeword not working for oc_capture, and automaticly unleash when capture ends

### DIFF
--- a/src/spares/Apps/oc_capture.lsl
+++ b/src/spares/Apps/oc_capture.lsl
@@ -219,6 +219,7 @@ Commit(){
         llMessageLinked(LINK_SET, LM_SETTING_SAVE, "auth_tempowner="+(string)g_kCaptor,"");
         llMessageLinked(LINK_SET, LM_SETTING_SAVE, "capture_isActive=1", ""); // <--- REMOVE AFTER NEXT RELEASE. This is here only for 7.3 compatibility
     }else{
+        llMessageLinked(LINK_SET, CMD_OWNER, "unleash", g_kCaptor);
         llMessageLinked(LINK_SET, LM_SETTING_DELETE, "auth_tempowner", "");
         llMessageLinked(LINK_SET, LM_SETTING_DELETE, "capture_isActive", ""); // <------ REMOVE AFTER NEXT RELEASE
     }
@@ -238,7 +239,7 @@ default
     
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_NOACCESS) UserCommand(iNum, sStr, kID);
-        else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
+        if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
         else if(iNum == -99999){
             if(sStr == "update_active")state inUpdate;


### PR DESCRIPTION
The first else in the link_message event made it impossible for the CMD_SAFEWORD condition to be checked.
Added a linkmessage to capture end to automaticly unleash because the captor will not be able to do so  when capture ended.
