### PR TITLE
Fix load timing on login

### DIFF
--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -336,7 +336,7 @@ default {
     on_rez(integer iParam) {
         if (g_kWearer == llGetOwner()) {
             g_iCheckNews = TRUE;
-            llSetTimerEvent(2.0);
+            llSetTimerEvent(7.0);
             //llSleep(0.5); // brief wait for others to reset
             //llMessageLinked(LINK_SET,LINK_UPDATE,"LINK_SET","");
             //SendValues();

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -336,7 +336,7 @@ default {
     on_rez(integer iParam) {
         if (g_kWearer == llGetOwner()) {
             g_iCheckNews = TRUE;
-            llSetTimerEvent(7.0);
+            llSetTimerEvent(10.0);
             //llSleep(0.5); // brief wait for others to reset
             //llMessageLinked(LINK_SET,LINK_UPDATE,"LINK_SET","");
             //SendValues();

--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -687,6 +687,7 @@ default {
 
     on_rez(integer iParam) {
         g_iHide=!(integer)llGetAlpha(ALL_SIDES) ; //check alpha
+        llSleep(10.0);
         init();
     }
 

--- a/src/collar/oc_sys.lsl
+++ b/src/collar/oc_sys.lsl
@@ -687,7 +687,7 @@ default {
 
     on_rez(integer iParam) {
         g_iHide=!(integer)llGetAlpha(ALL_SIDES) ; //check alpha
-        llSleep(10.0);
+        llSleep(7.0);
         init();
     }
 


### PR DESCRIPTION
Increased the time to wait in oc_settings before it starts to send all Settings. Some other scripts where not ready and did not receive the settings.

Added a Delay to oc_sys in the on_rez event. There was already a delay in the state_entry.
This should make the menu building more reliable after the wearer logged in.

In future we should replace llSleep in oc_sys with a timer to not build up a big event queue.