### PR TITLE
Readding "capture on" and "capture off" commands for oc_capture.

### DIFF
--- a/src/Apps/oc_capture.lsl
+++ b/src/Apps/oc_capture.lsl
@@ -142,6 +142,22 @@ UserCommand(integer iNum, string sStr, key kID) {
                 llSay(0,(string)g_iFlagAtLoad+" [InitialBootFlags]");
                 llSay(0, (string)g_kCaptor+" [TempOwner]");
                 llSay(0, (string)iNum+" [AuthLevel]");
+            }else if(sChangevalue=="on"){
+                if(g_iEnabled){
+                    llMessageLinked(LINK_SET,NOTIFY, "0Capture mode already enabled.", g_kWearer);
+                }else{
+                    llMessageLinked(LINK_SET,NOTIFY, "0Capture mode enabled.", g_kWearer);
+                    g_iEnabled=TRUE;
+                    Commit();
+                }
+            }else if(sChangevalue=="off"){
+                if(!g_iEnabled){
+                    llMessageLinked(LINK_SET,NOTIFY, "0Capture mode already disabled.", g_kWearer);
+                }else{
+                    llMessageLinked(LINK_SET,NOTIFY, "0Capture mode disabled.", g_kWearer);
+                    g_iEnabled=FALSE;
+                    Commit();
+                }
             }else if(sChangevalue==""){
                 // Attempt to capture
                 if(g_iCaptured){


### PR DESCRIPTION
The "capture on" and "capture off" commands disappeared between 7.3 and 7.4. This patch re-adds them, as they are quite convenient. It doesn't attempt to add any of the previous configuration commands, though.