### PR TITLE
tweak(addon/template): code readability, updated Link()

### DIFF
--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -198,9 +198,16 @@ default
                         string sMsg = llList2String(lMenuParams, 1);
                         integer iAuth = llList2Integer(lMenuParams, 3);
                         
-                        if (sMenu == "Menu~Main"){
-                            if (sMsg == UPMENU) Link("from_addon", iAuth, "menu Addons", kAv);
-                            else if (sMsg == "A Button") llSay(0, "This is an example addon.");
+                        if (sMenu == "Menu~Main")
+                        {
+                            if (sMsg == UPMENU)
+                            {
+                                Link("from_addon", iAuth, "menu Addons", kAv);
+                            }
+                            else if (sMsg == "A Button")
+                            {
+                                llSay(0, "This is an example addon.");
+                            }
                             else if (sMsg == "DISCONNECT")
                             {
                                 Link("offline", 0, "", llGetOwnerKey(g_kCollar));

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -136,7 +136,7 @@ default
     }
     
     listen(integer channel, string name, key id, string msg){
-        string sPacketType = sPacketType
+        string sPacketType = llJsonGetValue(msg, ["pkt_type"]);
         if (sPacketType == "approved" && g_kCollar == NULL_KEY)
         {
             // This signal, indicates the collar has approved the addon and that communication requests will be responded to if the requests are valid collar LMs.

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -3,7 +3,7 @@ THIS FILE IS HEREBY RELEASED UNDER THE Public Domain
 This script is released public domain, unlike other OC scripts for a specific and limited reason, because we want to encourage third party plugin creators to create for OpenCollar and use whatever permissions on their own work they see fit.  No portion of OpenCollar derived code may be used excepting this script,  without the accompanying GPLv2 license.
 -Authors Attribution-
 Aria (tiff589) - (August 2020)
-Lysea
+Lysea - (December 2020)
 */
 
 integer API_CHANNEL = 0x60b97b5e;

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -20,53 +20,46 @@ string g_sAddon = "Test Addon";
  */
 list g_lOptedLM     = [];
 
-integer CMD_ZERO = 0;
-integer CMD_OWNER = 500;
-integer CMD_TRUSTED = 501;
-integer CMD_GROUP = 502;
-integer CMD_WEARER = 503;
-integer CMD_EVERYONE = 504;
-integer CMD_BLOCKED = 598; // <--- Used in auth_request, will not return on a CMD_ZERO
-integer CMD_RLV_RELAY = 507;
-integer CMD_SAFEWORD = 510;
-integer CMD_RELAY_SAFEWORD = 511;
-integer CMD_NOACCESS=599;
+integer CMD_ZERO            = 0;
+integer CMD_OWNER           = 500;
+integer CMD_TRUSTED         = 501;
+integer CMD_GROUP           = 502;
+integer CMD_WEARER          = 503;
+integer CMD_EVERYONE        = 504;
+integer CMD_BLOCKED         = 598; // <--- Used in auth_request, will not return on a CMD_ZERO
+integer CMD_RLV_RELAY       = 507;
+integer CMD_SAFEWORD        = 510;
+integer CMD_RELAY_SAFEWORD  = 511;
+integer CMD_NOACCESS        = 599;
 
-integer LM_SETTING_SAVE = 2000;//scripts send messages on this channel to have settings saved, <string> must be in form of "token=value"
-integer LM_SETTING_REQUEST = 2001;//when startup, scripts send requests for settings on this channel
-integer LM_SETTING_RESPONSE = 2002;//the settings script sends responses on this channel
-integer LM_SETTING_DELETE = 2003;//delete token from settings
-integer LM_SETTING_EMPTY = 2004;//sent when a token has no value
+integer LM_SETTING_SAVE     = 2000; //scripts send messages on this channel to have settings saved, <string> must be in form of "token=value"
+integer LM_SETTING_REQUEST  = 2001; //when startup, scripts send requests for settings on this channel
+integer LM_SETTING_RESPONSE = 2002; //the settings script sends responses on this channel
+integer LM_SETTING_DELETE   = 2003; //delete token from settings
+integer LM_SETTING_EMPTY    = 2004; //sent when a token has no value
 
-integer ALIVE = -55;
-integer READY = -56;
-integer STARTUP = -57;
-
-integer SENSORDIALOG = -9003;
-integer SAY = 1004;
-
-integer DIALOG = -9000;
+integer DIALOG          = -9000;
 integer DIALOG_RESPONSE = -9001;
-integer DIALOG_TIMEOUT = -9002;
+integer DIALOG_TIMEOUT  = -9002;
 
 list g_lMenuIDs;
 integer g_iMenuStride;
 
-string UPMENU="BACK";
+string UPMENU = "BACK";
 
 Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
     key kMenuID = llGenerateKey();
     
-    llRegionSayTo(g_kCollar,API_CHANNEL, llList2Json(JSON_OBJECT, ["pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID]));
+    llRegionSayTo(g_kCollar, API_CHANNEL, llList2Json(JSON_OBJECT, [ "pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID ]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + g_iMenuStride - 1);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[Menu App]";
-    list lButtons = ["A Button"];
+    list lButtons  = ["A Button"];
     
     //llSay(0, "opening menu");
     Dialog(kID, sPrompt, lButtons, ["DISCONNECT", UPMENU], 0, iAuth, "Menu~Main");
@@ -74,31 +67,35 @@ Menu(key kID, integer iAuth) {
 
 UserCommand(integer iNum, string sStr, key kID) {
     if (iNum<CMD_OWNER || iNum>CMD_WEARER) return;
-    if (llSubStringIndex(llToLower(sStr),llToLower(g_sAddon)) && llToLower(sStr) != "menu "+llToLower(g_sAddon)) return;
+    if (llSubStringIndex(llToLower(sStr), llToLower(g_sAddon)) && llToLower(sStr) != "menu " + llToLower(g_sAddon)) return;
     if (iNum == CMD_OWNER && llToLower(sStr) == "runaway") {
         return;
     }
-    if (llToLower(sStr)==llToLower(g_sAddon) || llToLower(sStr) == "menu "+llToLower(g_sAddon)) Menu(kID, iNum);
-    //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
-    else {
-        integer iWSuccess = 0; 
-        string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
+
+    if (llToLower(sStr) == llToLower(g_sAddon) || llToLower(sStr) == "menu "+llToLower(g_sAddon))
+    {
+        Menu(kID, iNum);
+    } //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
+    else
+    {
+        integer iWSuccess   = 0; 
+        string sChangetype  = llList2String(llParseString2List(sStr, [" "], []),0);
         string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         string sText;
-        
     }
 }
 
 Link(string packet, integer iNum, string sStr, key kID){
-    list packet_data = ["pkt_type", packet, "iNum", iNum, "addon_name", g_sAddon, "bridge", FALSE, "sMsg", sStr, "kID", kID];
+    list packet_data = [ "pkt_type", packet, "iNum", iNum, "addon_name", g_sAddon, "bridge", FALSE, "sMsg", sStr, "kID", kID ];
 
     if (packet == "online" || packet == "update") // only add optin if packet type is online or update
     {
-        packet_data += ["optin", g_lOptedLM];
+        packet_data += [ "optin", g_lOptedLM ];
     }
 
     string pkt = llList2Json(JSON_OBJECT, packet_data);
-    if (g_kCollar != "" && g_kCollar != NULL_KEY) {
+    if (g_kCollar != "" && g_kCollar != NULL_KEY)
+    {
         llRegionSayTo(g_kCollar, API_CHANNEL, pkt);
     }
     else
@@ -115,65 +112,67 @@ default
 {
     state_entry()
     {
-        API_CHANNEL = ((integer)("0x"+llGetSubString((string)llGetOwner(),0,8)))+0xf6eb-0xd2;
+        API_CHANNEL = ((integer)("0x" + llGetSubString((string)llGetOwner(), 0, 8))) + 0xf6eb - 0xd2;
         llListen(API_CHANNEL, "", "", "");
-        Link("online", 0, "", llGetOwner(), ["optin", llDumpList2String([READY, SAY, SENSORDIALOG], "~")]); // This is the signal to initiate communication between the addon and the collar
-
+        Link("online", 0, "", llGetOwner()); // This is the signal to initiate communication between the addon and the collar
         llSetTimerEvent(60);
     }
     
     timer()
     {
-        if (llGetUnixTime() >= (g_iLMLastSent + 30)){
+        if (llGetUnixTime() >= (g_iLMLastSent + 30))
+        {
             g_iLMLastSent = llGetUnixTime();
             Link("ping", 0, "", g_kCollar);
         }
 
-        if (llGetUnixTime() > (g_iLMLastRecv + (5 * 60)) && g_kCollar != NULL_KEY) {
+        if (llGetUnixTime() > (g_iLMLastRecv + (5 * 60)) && g_kCollar != NULL_KEY)
+        {
             g_kCollar = NULL_KEY;
             llResetScript(); // perform our action on disconnect
         }
         
-        if (g_kCollar==NULL_KEY) Link("online", 0, "", llGetOwner());
+        if (g_kCollar == NULL_KEY) Link("online", 0, "", llGetOwner());
     }
     
     listen(integer channel, string name, key id, string msg){
         string sPacketType = sPacketType
-        if(sPacketType == "approved" && g_kCollar ==  NULL_KEY)
+        if (sPacketType == "approved" && g_kCollar == NULL_KEY)
         {
             // This signal, indicates the collar has approved the addon and that communication requests will be responded to if the requests are valid collar LMs.
             g_kCollar = i;
-            Link("from_addon", LM_SETTING_REQUEST, "ALL","");
+            Link("from_addon", LM_SETTING_REQUEST, "ALL", "");
         }
         else if (sPacketType == "dc" && g_kCollar == id)
         {
-            g_kCollar=NULL_KEY;
+            g_kCollar = NULL_KEY;
             llResetScript(); // This addon is designed to always be connected because it is a test
         }
-        else if (sPacketType == "pong" && g_kCollar == i)
+        else if (sPacketType == "pong" && g_kCollar == id)
         {
             g_iLMLastRecv = llGetUnixTime();
         }
         else if(sPacketType == "from_collar")
         {
             // process link message if in range of addon
-            if (llVecDist(llGetPos(), llList2Vector(llGetObjectDetails(i, [OBJECT_POS]),0)) <= 10.0)
+            if (llVecDist(llGetPos(), llList2Vector(llGetObjectDetails(i, [OBJECT_POS]), 0)) <= 10.0)
             {
-                // process it!
-                integer iNum = (integer)llJsonGetValue(msg, ["iNum"]);
-                string sStr = llJsonGetValue(msg, ["sMsg"]);
-                key kID = (key)llJsonGetValue(msg, ["kID"]);
+                integer iNum = (integer) llJsonGetValue(msg, ["iNum"]);
+                string sStr  = llJsonGetValue(msg, ["sMsg"]);
+                key kID      = (key) llJsonGetValue(msg, ["kID"]);
                 
                 if (iNum == LM_SETTING_RESPONSE)
                 {
-                    list lPar = llParseString2List(sStr, ["_","="],[]);
-                    string sToken = llList2String(lPar,0);
-                    string sVar = llList2String(lPar,1);
-                    string sVal = llList2String(lPar,2);
+                    list lPar     = llParseString2List(sStr, ["_","="], []);
+                    string sToken = llList2String(lPar, 0);
+                    string sVar   = llList2String(lPar, 1);
+                    string sVal   = llList2String(lPar, 2);
                     
-                    if(sToken == "auth"){
-                        if(sVar == "owner"){
-                            llSay(0, "owner values is: "+sVal);
+                    if (sToken == "auth")
+                    {
+                        if (sVar == "owner")
+                        {
+                            llSay(0, "owner values is: " + sVal);
                         }
                     }
                 }
@@ -190,23 +189,23 @@ default
                 else if (iNum == DIALOG_RESPONSE)
                 {
                     integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                    if (iMenuIndex!=-1)
+                    if (iMenuIndex != -1)
                     {
-                        string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
-                        list lMenuParams = llParseString2List(sStr, ["|"],[]);
-                        key kAv = llList2Key(lMenuParams,0);
-                        string sMsg = llList2String(lMenuParams,1);
-                        integer iAuth = llList2Integer(lMenuParams,3);
+                        string sMenu = llList2String(g_lMenuIDs, iMenuIndex + 1);
+                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                        list lMenuParams = llParseString2List(sStr, ["|"], []);
+                        key kAv = llList2Key(lMenuParams, 0);
+                        string sMsg = llList2String(lMenuParams, 1);
+                        integer iAuth = llList2Integer(lMenuParams, 3);
                         
                         if (sMenu == "Menu~Main"){
                             if (sMsg == UPMENU) Link("from_addon", iAuth, "menu Addons", kAv);
-                            else if (sMsg == "A Button") llSay(0, "This is a example addon.");
+                            else if (sMsg == "A Button") llSay(0, "This is an example addon.");
                             else if (sMsg == "DISCONNECT")
                             {
-                                Link("offline", 0, "",llGetOwnerKey(g_kCollar));
-                                g_lMenuIDs=[];
-                                g_kCollar=NULL_KEY;
+                                Link("offline", 0, "", llGetOwnerKey(g_kCollar));
+                                g_lMenuIDs = [];
+                                g_kCollar = NULL_KEY;
                             }
                         }
                     }

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -90,7 +90,7 @@ Link(string packet, integer iNum, string sStr, key kID){
 
     if (packet == "online" || packet == "update") // only add optin if packet type is online or update
     {
-        llListInsertList(packet_data, [ "optin", g_lOptedLM ], -1);
+        llListInsertList(packet_data, [ "optin", llDumpList2String(g_lOptedLM, "~") ], -1);
     }
 
     string pkt = llList2Json(JSON_OBJECT, packet_data);

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -11,6 +11,14 @@ integer API_CHANNEL = 0x60b97b5e;
 list g_lCollars;
 string g_sAddon = "Test Addon";
 
+/*
+ * Since Release Candidate 1, Addons will not receive all link messages without prior opt-in.
+ * To opt in, add the needed link messages to g_lOptedLM = [], they'll be transmitted on
+ * the initial registration and can be updated at any time by sending a packet of type `update`
+ * Following LMs require opt-in:
+ * [ALIVE, READY, STARTUP, CMD_ZERO, MENUNAME_REQUEST, MENUNAME_RESPONSE, MENUNAME_REMOVE, SAY, NOTIFY, DIALOG, SENSORDIALOG]
+ */
+list g_lOptedLM     = [];
 
 integer CMD_ZERO = 0;
 integer CMD_OWNER = 500;
@@ -81,11 +89,12 @@ UserCommand(integer iNum, string sStr, key kID) {
     }
 }
 
-Link(string packet, integer iNum, string sStr, key kID, list lLinkParams){
+Link(string packet, integer iNum, string sStr, key kID){
     list packet_data = ["pkt_type", packet, "iNum", iNum, "addon_name", g_sAddon, "bridge", FALSE, "sMsg", sStr, "kID", kID];
-    if (llGetListLength(lLinkParams) >= 2) // only append if there's a minimum of one key=value set
+
+    if (packet == "online" || packet == "update") // only add optin if packet type is online or update
     {
-        packet_data += lLinkParams;
+        packet_data += ["optin", g_lOptedLM];
     }
 
     string pkt = llList2Json(JSON_OBJECT, packet_data);


### PR DESCRIPTION
Hi,

I've modified the code for oc_addon_template.lsl for better readability.

Additionally, as OC8.0 RC1 was recently released, Link() was extended with `lLinkParams` to support extra fields (for eg. optin).

PR can be closed if there's already a rewrite of this template in progress.

Thanks!