### PR TITLE
meta(gha/lint): Add linting via lslint to GHA

### DIFF
--- a/.github/workflows/lslint.yml
+++ b/.github/workflows/lslint.yml
@@ -1,0 +1,25 @@
+name: LSLint
+
+on: [push, pull_request,workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      LSLINT_VER: v1.2.6
+      LSLINT_ENV: linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Download prerequisite: Makopo/lslint"
+        run: |
+          wget -O lslint.zip "https://github.com/Makopo/lslint/releases/download/${LSLINT_VER}/lslint_${LSLINT_VER}_${LSLINT_ENV}.zip"
+          unzip -j lslint.zip "lslint" -d "${{ github.workspace }}"
+
+      - name: Run Linting Script
+        run: |
+          chmod +x ${{github.workspace}}/run_lslint.sh
+          chmod +x ${{github.workspace}}/lslint
+          ${{github.workspace}}/run_lslint.sh ${{github.workspace}}/lslint

--- a/run_lslint.sh
+++ b/run_lslint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+shopt -s globstar
+set -o pipefail
+
+LSLINT_PATH=$1
+FAILED=.
+
+for file in **/*.lsl; do
+    echo "[>>] Linting $file..." | tee -a ./test.run.txt
+    $1 "$file" 2>&1 | tee -a ./test.run.txt
+    
+    if [ ${PIPESTATUS[0]} != 0 ] ; then
+        echo "[!!] Linting failed on $file" | tee -a ./test.run.txt
+        FAILED=$FAILED.
+    else
+        echo "[>>] Linting passed" | tee -a ./test.run.txt
+    fi
+done
+
+if [ $FAILED != . ] ; then
+  echo "[!!!] Linting failed on ${#FAILED} files - check the logs."
+  exit ${#FAILED}
+fi


### PR DESCRIPTION
This PR adds automatic linting of Pull Requests and Pushes (any branch).

run_lslint.sh is derivated from the original lslint test.sh script (see https://github.com/Makopo/lslint/blob/master/test.sh)

Action has been tested on ubuntu-latest, as well as debian buster (unavailable with GHA shared runners)

See example run here: https://github.com/lyseah/OpenCollar/runs/2108228764