### PR TITLE
Remove old CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run: sudo apt install make curl unzip
-      - run: make lint

--- a/.github/workflows/lslint.yml
+++ b/.github/workflows/lslint.yml
@@ -22,5 +22,4 @@ jobs:
       - name: Run Linting Script
         run: |
           chmod +x ${{github.workspace}}/run_lslint.sh
-          chmod +x ${{github.workspace}}/lslint
-          ${{github.workspace}}/run_lslint.sh ${{github.workspace}}/lslint
+          ${{github.workspace}}/run_lslint.sh ${{github.workspace}}/linter/lslint

--- a/.github/workflows/lslint.yml
+++ b/.github/workflows/lslint.yml
@@ -6,17 +6,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      LSLINT_VER: v1.2.6
-      LSLINT_ENV: linux
-
     steps:
       - uses: actions/checkout@v2
 
       - name: "Download prerequisite: Makopo/lslint"
+        uses: actions/checkout@v2
+        with:
+          repository: "Makopo/lslint"
+          path: "linter"
+      - name: "Compile Linter"
         run: |
-          wget -O lslint.zip "https://github.com/Makopo/lslint/releases/download/${LSLINT_VER}/lslint_${LSLINT_VER}_${LSLINT_ENV}.zip"
-          unzip -j lslint.zip "lslint" -d "${{ github.workspace }}"
+          cd linter
+          make
 
       - name: Run Linting Script
         run: |

--- a/run_lslint.sh
+++ b/run_lslint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 LSLINT_PATH=$1
 FAILED=.
 
-for file in **/*.lsl; do
+for file in src/**/*.lsl; do
     echo "[>>] Linting $file..." | tee -a ./test.run.txt
     $1 "$file" 2>&1 | tee -a ./test.run.txt
     


### PR DESCRIPTION
This PR does a few things

* Remove Circle CI config
* Update github action config to only scan the src folder.
* Update github action config to not use wget, and instead compiles a fresh copy of lslint.