### PR TITLE
Fix oc_relay not restoring restrictions correctly after login

### DIFF
--- a/src/collar/oc_relay.lsl
+++ b/src/collar/oc_relay.lsl
@@ -296,7 +296,7 @@ Process(string msg, key id, integer iWillPrompt){
                 }
                 @skipSection;
             }
-            else if (command=="!pong" && id == forcesitter && sitid != NULL_KEY) g_iResit_status = 1;
+            else if (command=="!pong" && id == Source ) g_iResit_status = 1;
             else if (command=="!version") llRegionSayTo(id, RLV_RELAY_CHANNEL, ident+","+(string)id+",!version,1100");
             else if (command=="!implversion") llRegionSayTo(id, RLV_RELAY_CHANNEL, ident+","+(string)id+",!implversion,ORG=805000/Satomi's Damn Fast Relay v4:OPENCOLLAR");
             else if (command=="!x-orgversions") llRegionSayTo(id, RLV_RELAY_CHANNEL, ident+","+(string)id+",!x-orgversions,ORG=805000");
@@ -375,12 +375,19 @@ state active
     timer() {
         if (g_iResit_status == 1) {
             g_iResit_status = 2;
-            llSetTimerEvent(15);
-            llOwnerSay("@sit:"+(string)sitid+"=force");
+            llSetTimerEvent(20);   //this must be long enough to happen AFTER oc_rlvsys is initialised or restrictions get cleared again
+			//only do the force-sit if the wearer was indeed locked sitting on something
+            if( Source == forcesitter && sitid != NULL_KEY ) {
+                llOwnerSay("@sit:"+(string)sitid+"=force");
+            }
         } else if (g_iResit_status == 2) {
             llSetTimerEvent(0);
-            llOwnerSay("@"+llDumpList2String(Restrictions, "=n,")+"=n");
-        } else Release(); // The source is no longer active. Let's forget everything.
+			// this must also restore detach=n as oc_rlvsys may have cleared it
+            llOwnerSay("@"+llDumpList2String(Restrictions, "=n,")+"=n,detach=n");
+        } else {
+            llSetTimerEvent(0);
+            Release(); // The source is no longer active. Let's forget everything.
+        }
     }
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) UserCommand(iNum, sStr, kID);


### PR DESCRIPTION
I found several issues with the OpenCollar 8.0.5 relay when restoring restrictions from a device after logging in:

1) The relay will only restore restrictions from a device that the user has been forced to sit on. In the case of a walk-in cage or cell where the victim is not actually sitting on the device, it will not restore the restrictions but instead sends a "!release" command to force the device to release restrictions.

2) On user log-in, there's a race condition between the oc_relay script starting up and restoring restrictions, and the oc_rlvsys starting up. If oc_rlvsys starts up after oc_relay, it issues an RLV "@clear" to the viewer which removes all restrictions restored by oc_relay. Depending on the exact timing on a particular log-in, it may wipe all restrictions restored by the relay, or just the detach restriction intended to prevent collar removal while restrictions are active.

3) If a device that applied restrictions before log out is no longer present when the user logs back in, the relay will send RLV "!release" messages to nothing every 30 seconds forever. This is a source of region lag.

RLV restrictions are restored after login based on the RLV relay ping/pong protocol. Relay sends a ping to the device, if it gets a pong, it should restore the restrictions. In oc_relay, the ping is sent from the on_rez() function, if the relay has restrictions from the previous session, then it sets 'g_iResit_status' to 0 and sets a 30 second timer. The RLV listener receives the "!pong" response in the listen() handler and changes the value of 'g_iResit_status' to 1 if it is valid. When the timer fires, the timer() function either does a force sit or releases restrictions depending on the value of 'g_iResit_status'. 

This patch fixes the issues as follows:

First part of the fix goes in the listen() function where the "!pong" response is validated. It needs to check the source id of the message matches the source of the restrictions, rather than an object that issued a force-sit (because there may not have been a force-sit at all). 

Secondly, the timer() handler that actually restores the restrictions needs to change in four ways:
1) to only do a force sit if there was a force-sit applied prior to log out, since this is no longer checked at the !pong stage
2) to delay a bit longer before restoring restrictions so that oc_rlvsys doesn't clear them, the existing 30 seconds time for the pong plus 15 seconds isn't always enough in my experience. Extending the second timer to 20 seconds seems good.
3) to restore the detach=n restriction at the same time because oc_rlvsys can have cleared it
4) to cancel the timer if restrictions are being released - otherwise the relay continues to send RLV "!release" messages every 30 seconds forever, which can prevent the wearer being locked by other devices.
