### PR TITLE
fix random teleport reset of addon scripts

### DIFF
--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -125,6 +125,10 @@ default
         if(id)
         {
             Link("online", 0, "", llGetOwner());
+            // do like state_entry to fix random resets on teleport or login.
+            llSetTimerEvent(60);
+            g_iLMLastRecv = llGetUnixTime();
+        }
         }
         else
         {


### PR DESCRIPTION
this should fix addon scripts reseting when you teleport or log in meaning addon specific configuration changes can be saved to the addon.