### PR TITLE
Boot process speedup

### DIFF
--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -1,19 +1,19 @@
-
 /*
 This file is a part of OpenCollar.
 Copyright ©2021
-
-
 : Contributors :
 All contributors of previous revision of oc_settings
-
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
 
+Medea Destiny
+        Sept 2021   -   Tightened timings on release of all settings and reduced sleep
+                        padding on initialize
 */
 
 //string g_sParentMenu = "Apps";
+
 
 integer TIMEOUT_REGISTER = 30498;
 integer TIMEOUT_FIRED = 30499;
@@ -509,7 +509,7 @@ default
                 g_iBootup=FALSE;
             }
             llSetTimerEvent(0);
-        }else llSetTimerEvent(0.25); // send 1 setting per quarter second
+        }else llSetTimerEvent(0.15); // 0.25 send 1 setting per quarter second
     }
 
 
@@ -598,7 +598,7 @@ default
                 llSleep (5); // Sleep for 5 seconds to give some padding for all scripts to switch to the ready state!
                 g_iBootup=TRUE;
                 g_iCurrentIndex=0;
-                llSetTimerEvent(5);
+                llSetTimerEvent(0.5); //5
             }
         }
         //llOwnerSay(llDumpList2String([iSender,iNum,sStr,kID],"^"));

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -509,7 +509,7 @@ default
                 g_iBootup=FALSE;
             }
             llSetTimerEvent(0);
-        }else llSetTimerEvent(0.15); // 0.25 send 1 setting per quarter second
+        }else llSetTimerEvent(0.15); // send 1 setting per 0.15 second (previous - 0.25)
     }
 
 

--- a/src/collar/oc_states.lsl
+++ b/src/collar/oc_states.lsl
@@ -1,25 +1,22 @@
-  
 /*
 This file is a part of OpenCollar.
 Copyright ©2020
-
-
 : Contributors :
-
 Aria (Tashia Redrose)
     *August 2020        -       *Created oc_states
                                 *Due to significant issues with original implementation, States has been turned into a anti-crash
                                 script instead of a script state manager.
                                 *Repurpose oc_states to be anti-crash and a interactive settings editor.
 Medea (Medea Destiny)
-    *July 2021          -       *See issue #587: Added warning when script resets folders script that user should consider cleaning up their #RLV                                
+    *July 2021          -       *See issue #587: Added warning when script resets folders script that user should consider cleaning
+                                up their #RLV 
+    Sept 2021           -       Tighten timings and number of passes on reboot process and reduced sleep padding.                               
                                             
     
     
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
-
 */
 
 
@@ -170,7 +167,7 @@ list g_lTimers; // signal, start_time, seconds_from
 
 integer g_iExpectAlive=0;
 list g_lAlive;
-integer g_iPasses=-1;
+integer g_iPasses=0;
 
 
 integer ALIVE = -55;
@@ -187,8 +184,8 @@ default
         g_iExpectAlive=1;
         llSetTimerEvent(1);
         //llScriptProfiler(TRUE);
-        llMessageLinked(LINK_SET, REBOOT,"reboot", "");
-        llSleep(5);
+      //  llMessageLinked(LINK_SET, REBOOT,"reboot", "");
+        //llSleep(5);
         //llMessageLinked(LINK_SET, 0, "initialize", "");
         if(g_iVerbosityLevel>=1)
             llOwnerSay("Collar is preparing to startup, please be patient.");
@@ -196,26 +193,26 @@ default
     
     
     on_rez(integer iRez){
-        llSleep(10);
+        //llSleep(10);
         llResetScript();
     }
     
     timer(){
         
         if(g_iExpectAlive){
-            if(llGetTime()>=5 && g_iPasses<3){
+            if(llGetTime()>=3 && g_iPasses<2){ //>=5
                 llMessageLinked(LINK_SET,READY, "","");
                 llResetTime();
                 //llSay(0, "PASS COUNT: "+(string)g_iPasses);
                 g_iPasses++;
-            } else if(llGetTime()>=7.5 && g_iPasses>=3){
+            } else if(llGetTime()>=2 && g_iPasses>=2){ //>=7.5
                 if(g_iVerbosityLevel>=2)
                     llOwnerSay("Scripts ready: "+(string)llGetListLength(g_lAlive));
                 llMessageLinked(LINK_SET,STARTUP,llDumpList2String(g_lAlive,","),"");
                 g_iExpectAlive=0;
                 g_lAlive=[];
                 g_iPasses=0;
-                llSleep(10);
+                llSleep(1); //10
                 
                 if(g_iVerbosityLevel >=1)
                     llMessageLinked(LINK_SET,NOTIFY,"0Startup in progress... be patient", llGetOwner());
@@ -427,12 +424,14 @@ default
             if(sStr == "update_active")state inUpdate;
         } else if(iNum == ALIVE){
             g_iExpectAlive=1;
-            llResetTime();
-            llSetTimerEvent(1);
+            //llResetTime();
+            //llSetTimerEvent(1);
             if(llListFindList(g_lAlive,[sStr])==-1){
                 g_iPasses=0;
                 g_lAlive+=[sStr];
-            }
+            }else return;
+            llResetTime();
+            llSetTimerEvent(1);            
         }
     }
 }


### PR DESCRIPTION
These changes make the boot process / timings much more aggressive. 

I have been running with these changes for 2 weeks now without issue, and have passed them on to our testers to play with. My estimate is that it roughly halves the boot time. @Trinkitz feels this might be conservative. 

These changes will mean the boot process is less bullet-proof, so thorough testing over time and in particularly laggy sims, of login, attaching and fix menus function should be done before okaying this, but I have yet to experience a single problem. 