### PR TITLE
Speedup bootup by responding to other script feedback.

### DIFF
--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -15,6 +15,90 @@ https://github.com/OpenCollarTeam/OpenCollar
 
 //string g_sParentMenu = "Apps";
 
+
+integer g_iSettingsLoaded;
+integer g_iLastStride;
+string  g_sVariableView;
+string  g_sTokenView="";
+
+// return a CSV containing all global_var=val
+string SettingsFor(string SelectToken){
+    list lSettings;    
+    integer i = llGetListLength(g_lSettings); 
+    while((i-=2)>=0){        
+        list lTmp = llParseString2List(llList2String(g_lSettings,i),["_"],[]);
+        string sTok = llList2String(lTmp,0);
+        string sVar = llList2String(lTmp,1);
+        if(sTok == SelectToken)
+            lSettings+=llList2String(g_lSettings,i)+"="+llList2String(g_lSettings,i+1);
+    }
+    return llList2CSV(lSettings);
+}
+
+// sends "ALIVE oc_setttings <global_var=val list>"
+sendALIVE(){
+        g_iSettingsLoaded = TRUE;
+        llSetTimerEvent(0);   
+        llMessageLinked(LINK_SET, ALIVE, "oc_settings", SettingsFor("global")); 
+}
+
+// dialogs for "settings edit"
+SettingsMenu(integer stridePos, key kAv, integer iAuth){
+    string sText = "OpenCollar - Interactive Settings editor";
+    list lButtons = [];
+    if(iAuth != CMD_OWNER){
+        sText+="\n\nOnly owner may use this feature";
+        Dialog(kAv, sText, [], [UPMENU], 0, iAuth, "Menu~Main");
+        return;
+    }
+    integer end = llGetListLength(g_lSettings); integer i;
+    if(stridePos == 0){
+        for(i=0;i<end;i+=2){
+            list lSetting = llParseString2List(llList2String(g_lSettings,i), ["_"],[]);            
+            string sToken = llList2String(lSetting,0);
+            if(llListFindList(lButtons,[sToken])==-1)lButtons+=sToken;
+        }                         
+        sText+="\nCurrently viewing Tokens";
+    } else if(stridePos==1){
+        for(i=0;i<end;i+=2){
+            list lToken_Var = llParseString2List(llList2String(g_lSettings,i), ["_"],[]);            
+            string sToken = llList2String(lToken_Var,0);          
+            string sVar = llList2String(lToken_Var,1);
+            if(sToken==g_sTokenView)lButtons+=sVar;
+        }        
+        sText+="\nCurrently viewing Variables for token '"+g_sTokenView+"'";
+    } else if(stridePos == 2){
+        integer iPos = llListFindList(g_lSettings,[g_sTokenView+"_"+g_sVariableView]);
+        if(iPos==-1){
+            // cannot do it
+            lButtons=[];
+            sText+="\nCurrently viewing the variable '"+g_sTokenView+"_"+g_sVariableView+"'\nNo data found";
+        } else {
+            lButtons = ["DELETE", "MODIFY"];
+            sText = "\nCurrently viewing the variable '"+g_sTokenView+"_"+g_sVariableView+"'\nData contained in var: "+llList2String(g_lSettings, iPos+1);
+        }
+    } else if(stridePos==3){
+        integer iPos = llListFindList(g_lSettings,[g_sTokenView+"_"+g_sVariableView]);
+        
+        sText+="\n\nPlease enter a new value for: "+g_sTokenView+"_"+g_sVariableView+"\n\nCurrent value: "+llList2String(g_lSettings, iPos+1);
+        lButtons =[];
+    } else if(stridePos==8){
+        sText+= "\n\nPlease enter the token name";
+        lButtons=[];
+    } else if(stridePos == 9){
+        sText += "\n\nPlease enter the variable name for '"+g_sTokenView;
+        lButtons=[];
+    }
+    
+    g_iLastStride=stridePos;
+    Dialog(kAv, sText,lButtons, setor((lButtons!=[]), ["+ NEW", UPMENU], []), 0, iAuth, "settings~edit~"+(string)stridePos);    
+}
+
+list setor(integer test, list a, list b){
+    if(test)return a;
+    else return b;
+}
+
 integer TIMEOUT_REGISTER = 30498;
 integer TIMEOUT_FIRED = 30499;
 
@@ -104,7 +188,7 @@ integer LM_SETTING_EMPTY = 2004;//sent when a token has no value
 //integer MENUNAME_REMOVE = 3003;
 
 //integer RLV_CMD = 6000;
-//integer RLV_REFRESH = 6001;//RLV plugins should reinstate their restrictions upon receiving this message.
+integer RLV_REFRESH = 6001;//RLV plugins should reinstate their restrictions upon receiving this message.
 
 //integer RLV_OFF = 6100; // send to inform plugins that RLV is disabled now, no message or key needed
 //integer RLV_ON = 6101; // send to inform plugins that RLV is enabled now, no message or key needed
@@ -112,8 +196,13 @@ integer LM_SETTING_EMPTY = 2004;//sent when a token has no value
 integer DIALOG = -9000;
 integer DIALOG_RESPONSE = -9001;
 integer DIALOG_TIMEOUT = -9002;
-//string UPMENU = "BACK";
+string UPMENU = "BACK";
 //string ALL = "ALL";
+
+
+integer ALIVE = -55;
+integer READY = -56;
+integer STARTUP = -57;
 
 /*//--                       Anti-License Text                         --//*/
 /*//     Contributed Freely to the Public Domain without limitation.     //*/
@@ -276,6 +365,8 @@ UserCommand(integer iNum, string sStr, key kID) {
             g_iCurrentIndex=0;
             llSetTimerEvent(10);
         }
+    }else if(sLower=="settings edit"){
+        SettingsMenu(0, kID, iNum);
     }
 }
 integer g_iRebootConfirmed=FALSE;
@@ -473,6 +564,7 @@ default
             g_kSettingsCard = llGetInventoryKey(g_sSettings);
             g_kSettingsRead = llGetNotecardLine(g_sSettings, 0);
         }
+        else    sendALIVE();    // if there is no notecard, then no need to wait    
     }
 
     changed(integer iChange){
@@ -493,6 +585,7 @@ default
                 g_iCurrentIndex=0;
                 llSetTimerEvent(2);
                 llMessageLinked(LINK_SET, NOTIFY, "0Settings notecard loaded successfully", g_kWearer);
+                sendALIVE();   
             } else {
                 ProcessSettingLine(sData);
 
@@ -514,6 +607,7 @@ default
 
 
     link_message(integer iSender,integer iNum,string sStr,key kID){
+                
         if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) UserCommand(iNum, sStr, kID);
         //else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
         //    llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
@@ -544,6 +638,79 @@ default
                         g_iLoadURLConsented=TRUE;
                         g_kLoadURL = llHTTPRequest(g_sLoadURL, [], "");
                     }
+                } else if(sMenu == "Menu~Main"){
+                    if(sMsg == UPMENU){
+                        llMessageLinked(LINK_SET, iAuth, "menu Settings", kAv);
+                    }
+                } else if(sMenu == "settings~edit~0"){
+                    if(sMsg == UPMENU){
+                        llMessageLinked(LINK_SET, iAuth, "menu Settings", kAv);
+                        return;
+                    } else if(sMsg == "+ NEW"){
+                        SettingsMenu(8, kAv, iAuth);
+                        return;
+                    }
+                    if(sMsg == "intern" || sMsg == "auth"){
+                        llMessageLinked(LINK_SET, NOTIFY, "0Editing of the "+sMsg+" token is prohibited by the security policy", kAv);
+                        SettingsMenu(0, kAv, iAuth);
+                    } else {
+                        g_sTokenView=sMsg;
+                        SettingsMenu(1, kAv,iAuth);
+                    }
+                } else if(sMenu == "settings~edit~1"){
+                    if(sMsg==UPMENU){
+                        SettingsMenu(0,kAv,iAuth);
+                        return;
+                    }else if(sMsg == "+ NEW"){
+                        SettingsMenu(9, kAv, iAuth);
+                        return;
+                    }
+                    
+                    g_sVariableView=sMsg;
+                    SettingsMenu(2, kAv,iAuth);
+                    
+                } else if(sMenu == "settings~edit~2"){
+                    if(sMsg == UPMENU){
+                        SettingsMenu(1,kAv,iAuth);
+                        return;
+                    } else if(sMsg == "DELETE"){
+                        string  sToken = g_sTokenView+"_"+g_sVariableView;
+                        integer iPosx  = llListFindList(g_lSettings, [sToken]);
+                        if(iPosx==-1){
+                            SettingsMenu(2,kAv,iAuth);
+                            return;
+                        }                       
+                        if(!CheckModifyPerm(sStr, kID))return;
+                        
+                        llMessageLinked(LINK_SET, LM_SETTING_DELETE, g_sTokenView+"_"+g_sVariableView,"");
+                        llMessageLinked(LINK_SET, RLV_REFRESH,"","");
+                        llMessageLinked(LINK_SET, NOTIFY, "1"+sToken+" has been deleted from settings", kAv);
+                        return;
+                    } else if(sMsg == "MODIFY"){
+                        SettingsMenu(3, kAv,iAuth);
+                    }
+                } else if(sMenu == "settings~edit~3"){
+                    if(sMsg == UPMENU){
+                        SettingsMenu(2,kAv,iAuth);
+                    } else {
+                        string  sToken = g_sTokenView+"_"+g_sVariableView;
+                        integer iPosx  = llListFindList(g_lSettings, [sToken]);     
+                        if(iPosx == -1)SettingsMenu(2,kAv,iAuth);
+                        else{
+                            llMessageLinked(LINK_SET, LM_SETTING_SAVE, g_sTokenView+"_"+g_sVariableView+"="+sMsg,"");
+                            llMessageLinked(LINK_SET, NOTIFY, "1Settings modified: "+sToken+"="+sMsg,kAv);
+                            SettingsMenu(1,kAv,iAuth);
+                            return;
+                        }
+                    }
+                } else if(sMenu == "settings~edit~8"){
+                    g_sTokenView=sMsg;
+                    SettingsMenu(9, kAv,iAuth);
+                } else if(sMenu == "settings~edit~9"){
+                    g_sVariableView=sMsg;
+                    g_lSettings = SetSetting(g_sTokenView+"_"+g_sVariableView,"0");
+                    
+                    SettingsMenu(3, kAv,iAuth);
                 }
 
             }
@@ -600,8 +767,11 @@ default
                 g_iCurrentIndex=0;
                 llSetTimerEvent(5);
             }
+        } else if(iNum==REBOOT) {
+            if(g_iSettingsLoaded) sendALIVE(); // sent ALIVE on receiving REBOOT signal
         }
         //llOwnerSay(llDumpList2String([iSender,iNum,sStr,kID],"^"));
+            
     }
 
     http_response(key kID, integer iStatus, list lMeta, string sBody)

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -36,7 +36,7 @@ string SettingsFor(string SelectToken){
 }
 
 // sends "ALIVE oc_setttings <global_var=val list>"
-sendALIVE(){
+SendALIVE(){
         g_iSettingsLoaded = TRUE;
         llSetTimerEvent(0);   
         llMessageLinked(LINK_SET, ALIVE, "oc_settings", SettingsFor("global")); 
@@ -564,7 +564,7 @@ default
             g_kSettingsCard = llGetInventoryKey(g_sSettings);
             g_kSettingsRead = llGetNotecardLine(g_sSettings, 0);
         }
-        else    sendALIVE();    // if there is no notecard, then no need to wait    
+        else    SendALIVE();    // if there is no notecard, then no need to wait    
     }
 
     changed(integer iChange){
@@ -585,7 +585,7 @@ default
                 g_iCurrentIndex=0;
                 llSetTimerEvent(2);
                 llMessageLinked(LINK_SET, NOTIFY, "0Settings notecard loaded successfully", g_kWearer);
-                sendALIVE();   
+                SendALIVE();   
             } else {
                 ProcessSettingLine(sData);
 
@@ -768,7 +768,7 @@ default
                 llSetTimerEvent(5);
             }
         } else if(iNum==REBOOT) {
-            if(g_iSettingsLoaded) sendALIVE(); // sent ALIVE on receiving REBOOT signal
+            if(g_iSettingsLoaded) SendALIVE(); // sent ALIVE on receiving REBOOT signal
         }
         //llOwnerSay(llDumpList2String([iSender,iNum,sStr,kID],"^"));
             

--- a/src/collar/oc_states.lsl
+++ b/src/collar/oc_states.lsl
@@ -104,7 +104,7 @@ integer Alive(string scriptName){
     return FALSE;
 }
 
-integer antiCrash(string scriptName){
+integer AntiCrash(string scriptName){
     if(llGetScriptState(scriptName)==FALSE){
         llResetOtherScript(scriptName);
         llSleep(0.5);
@@ -122,7 +122,7 @@ integer antiCrash(string scriptName){
 Reboot(){        
     integer i = llGetListLength(g_lWaiting);
     while(i--)            
-        antiCrash(llList2String(g_lWaiting,i));                       
+        AntiCrash(llList2String(g_lWaiting,i));                       
         
     llMessageLinked(LINK_SET, REBOOT,"reboot", llGetScriptName());
     llSetTimerEvent(15);  
@@ -237,7 +237,7 @@ state running
         integer end = llGetInventoryNumber(INVENTORY_SCRIPT);
         integer iModified=FALSE;
         for(i=0;i<end;i++){
-            iModified+=antiCrash(llGetInventoryName(INVENTORY_SCRIPT, i));
+            iModified+=AntiCrash(llGetInventoryName(INVENTORY_SCRIPT, i));
         }        
         if(iModified) llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "ALL","");
         


### PR DESCRIPTION
Overhaul of oc_states to go through distinct states and waiting for feedback from other scripts before moving to the next state. oc_settings is now sending out an ALIVE signal on REBOOT/script reset, when the .settings notecard is loaded.
This helps make the bootup process move on as soon as the settings are loaded rather then wait an arbitrary sleep time.
A failsafe timeout is included in case a oc_settings is used that does not send ALIVE.

default state:
*    send REBOOT reboot
*    waits for ALIVE from oc_settings, oc_core, oc_api

state startup:
*    send STARTUP
*    waits for :
  0 initialize from oc_core
  LM_SETTING_REQUEST ALL from oc_api
  "settings=sent" from oc_settings

state running:
*    send TIMEOUT_READY



The settings editor is moved to oc_settings because that's where the settings are stored and editing them directly makes it a lot more responsive.

oc_settings ALIVE & oc_states STARTUP also sends global_ settings for early access to settings like global_locked and global_verbosity