### PR TITLE
Update oc_rlvextension.lsl

### DIFF
--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -39,7 +39,8 @@ Medea Destiny -
                     restrictions, remove the restriction, navigate back to UNSIT, unsit the collar
                     wearer, then navigate back to restrictions and reset it. This does that 
                     automatically for owners. 
-                -   Added explanatory text to exceptions and force sit menus                  
+                -   Added explanatory text to exceptions and force sit menus
+                -   Renamed Refuse TP to Force TP to reflect what the button actually does.                  
 
 */
 string g_sParentMenu = "RLV";


### PR DESCRIPTION
Changed "Refuse TP" button to "Force TP".

Okay, bare with me, this is complicated. The actual command that is relevant here is accepttp. When added, this accepts tp offers automatically. There has always been an issue with people understanding this setting in exceptions, because switching Accept TP on means that you don't get to accept TP offers, you get TPd automatically. To resolve this, some time ago in the dark days of 3.x this got changed to Refuse TP. When ticked, you could refuse TP offers. Nice and logical.

HOWEVER, for this to function, we have to make a special instance of the exception code. Where all the other buttons add the RLV command when on, the Refuse TP button adds accept when off. The 8.x code (I'm not sure at what point this was changed to work this way) has the exceptions as a binary mask and switches the restriction on when the button is on. SO as per 8.1, if you have Refuse TP ticked, you cannot refuse TP offers. If you don't have Refuse TP ticked, you can refuse TP offers, This is thoroughly confusing.

The simple solution I have implemented here is to change the button name to FORCE TP. Now if FORCE TP is on, you will be force TP'd when you get a TP offer. When the Force TP button is off, you won't. That seems a lot more logical. 
![0fe50260bfd7e4dc9784f7cb98cc27e2](https://user-images.githubusercontent.com/37522714/137070282-a7089b7a-fefc-4589-a797-e2bd0d1e5e92.png)


