### PR TITLE
Addon Timeout Removal correction

### DIFF
--- a/src/collar/oc_addons.lsl
+++ b/src/collar/oc_addons.lsl
@@ -287,7 +287,7 @@ state active
                     }
                     SayToAddonX((key)llList2String(g_lAddons,i), "dc", 0, "", llGetOwner());
                     llMessageLinked(LINK_SET, NOTIFY, "0Addon: "+llList2String(g_lAddons,i+1)+" has been removed because it has not been seen for 5 minutes or more.", g_kWearer);
-                    g_lAddons = llDeleteSubList(g_lAddons, i, i+5);
+                    g_lAddons = llDeleteSubList(g_lAddons, i, i+4);
                     i=-5; // if we change the stride of the list this must be updated
                     end=llGetListLength(g_lAddons);
                     if(g_iVerbosityLevel>=4)


### PR DESCRIPTION
The messages regarding removal of Addons did not correctly report the removals, because the list delete would remove 1 too many elements from the list.