### PR TITLE
Update oc_rlvsuite.lsl, fix for issue #723

### DIFF
--- a/src/collar/oc_rlvsuite.lsl
+++ b/src/collar/oc_rlvsuite.lsl
@@ -33,7 +33,9 @@ medea (medea destiny)
                     requirements of setting individual restrictions as short-term solution to issue #656. 
                 -   Added Restore function to Customize menu to restore presets to defaults, per issue #663
                 -   Rewritten dialog code to set individual restrictions, 'cos it was badly broken. Issue #664
-                    
+    Feb 2022    -   Fix for #732: Empty g_lMacros list returned via LM_SETTING_RESPONSE parses as a list with a single 
+                    empty element, thus messing up the list stride. Not sure why we're keeping nulls here, but setting
+                    to empty list if list length is too short works.                    
                 
                              
                              
@@ -766,7 +768,10 @@ state active
                     g_iRestrictions1 = llList2Integer(lMasks, 0);
                     g_iRestrictions2 = llList2Integer(lMasks, 1);
                 }
-            } else if (llList2String(lParams, 0) == "rlvsuite_macros") g_lMacros = llParseStringKeepNulls(llList2String(lParams, 1), ["^"],[]);
+            } else if (llList2String(lParams, 0) == "rlvsuite_macros") {
+                g_lMacros = llParseStringKeepNulls(llList2String(lParams, 1), ["^"],[]);
+                if(llGetListLength(g_lMacros)<3) g_lMacros=[];  
+            }
             else if(llList2String(lParams,0) == "global_checkboxes") g_lCheckboxes = llCSV2List(llList2String(lParams,1));
         } else if (iNum == CMD_SAFEWORD || iNum == RLV_CLEAR || iNum == RLV_OFF){
             g_iRLV = FALSE;

--- a/src/collar/oc_rlvsuite.lsl
+++ b/src/collar/oc_rlvsuite.lsl
@@ -35,7 +35,7 @@ medea (medea destiny)
                 -   Rewritten dialog code to set individual restrictions, 'cos it was badly broken. Issue #664
     Feb 2022    -   Fix for #732: Empty g_lMacros list returned via LM_SETTING_RESPONSE parses as a list with a single 
                     empty element, thus messing up the list stride. Not sure why we're keeping nulls here, but setting
-                    to empty list if list length is too short works.                    
+                    to empty list if list length is too short works.                   
                 
                              
                              


### PR DESCRIPTION
Fix for #723 

   If you delete all presets from the restrictions menu, the empty list is saved to settings as a blank string and will be restored as a list (g_lMacros) with a single empty element, due to the use of llParseString2ListKeepNulls rather than llParseString2List. The result is that you'll see a stray button appear in the menu with a checkbox but no text, as the empty list element will be treated in the menu function as a preset. Adding further presets will be broken because they will now be out of stride; the preset name will be read as the first mask value of the blank false preset, the first restriction mask will be added as the second restriction mask of the blank false preset, and the second restriction mask will be added as the button name for a new preset, with no mask values associated with it. This same pattern will hold for any further buttons added. The result: a mess.

I'm not sure why nulls are kept here, but rather than poking at that and trying to figure out if there's any case that's actually necessary, have fixed this by simply checking the length of the list - a single preset uses three elements, so if there are fewer than 3 present I set g_lMacros to []; 