### PR TITLE
Update oc_states.lsl

### DIFF
--- a/src/collar/oc_states.lsl
+++ b/src/collar/oc_states.lsl
@@ -185,7 +185,7 @@ default
         llSetTimerEvent(1);
         //llScriptProfiler(TRUE);
         if(g_iVerbosityLevel>=1)
-            llOwnerSay("Collar is preparing to startup, please be patient.");
+            llOwnerSay("Collar is preparing to start up, please be patient.");
     }
     
     


### PR DESCRIPTION
Fixed typo in boot message, "Collar is preparing to startup, please be patient." > ""Collar is preparing to start up, please be patient." Spotted by Toy.