### PR TITLE
"offline" commands for addons corrupt addon list

### DIFF
--- a/src/collar/oc_addons.lsl
+++ b/src/collar/oc_addons.lsl
@@ -369,7 +369,7 @@ state active
                         {
                             llOwnerSay("Pre-Addon Deletion List: "+llDumpList2String(g_lAddons,"~"));
                         }
-                        g_lAddons = llDeleteSubList(g_lAddons, iPos, iPos+5);
+                        g_lAddons = llDeleteSubList(g_lAddons, iPos, iPos+4);
                         if(g_iVerbosityLevel>=4)
                         {
                             llOwnerSay("Post-Addon Deletion List: "+llDumpList2String(g_lAddons,"~"));


### PR DESCRIPTION
The section of code which removes an addon from the addon list (g_lAddons) when and 'offline' chat message is received removes one too many list elements, thereby corrupting the list.  The stride is 5, but 6 elements (ipos, ipos+5 = 6) are removed.   This problem is similar to #718 