### PR TITLE
simple correction for lock guard

### DIFF
--- a/src/collar/oc_particle.lsl
+++ b/src/collar/oc_particle.lsl
@@ -745,8 +745,8 @@ state active
             if (llList2String(lLGCmd,0) == "lockguard") {
                 key kLGAv = llList2Key(lLGCmd,1);           // Request Avatar-UUID
                 string sLGPoint = llList2String(lLGCmd,2);  // Request ChainPoint
-                string sLGCMD = llList2String(lLGCmd,3);    // Request Command
-                key kLGTarget = llList2Key(lLGCmd,4);       // Request Target
+                key kLGTarget = llList2Key(lLGCmd,3);       // Request Target
+                string sLGCMD = llList2String(lLGCmd,4);    // Request Command
 
                 // check that we are within leash length
                 integer point = llList2Integer(llGetObjectDetails(kLGTarget, [OBJECT_ATTACHED_POINT]),0);


### PR DESCRIPTION
a conversation in R&D about lock guard communicability exposed that we had the order of command wrong target comes before user key
https://wiki.secondlife.com/wiki/LSL_Protocol/LockGuard