### PR TITLE
Create oc_debugger

### DIFF
--- a/src/spares/oc_debugger
+++ b/src/spares/oc_debugger
@@ -1,4 +1,6 @@
 /*
+This application is not recomended for regular users.
+
 This is a Basic debugger it manages messages fromt he script that don't always need to be seen in three categories
 Info - Basic information like the addons getting kicked for inactivity.
 Warning - Information about problems that won't break the collar but could cause instability.

--- a/src/spares/oc_debugger
+++ b/src/spares/oc_debugger
@@ -1,4 +1,19 @@
 /*
+This is a Basic debugger it manages messages fromt he script that don't always need to be seen in three categories
+Info - Basic information like the addons getting kicked for inactivity.
+Warning - Information about problems that won't break the collar but could cause instability.
+Errors - Information that Will or May cause the collar to break entirely.
+
+by Default the system is inactive, and set to info.
+Errors are the only exception and get put in DEBUG_CHANNEL like normal script errors, as well as normal output you select.
+Errors also get displayed while the app is inactive.
+
+you get two options for output
+Private and Public
+Private - llOwnerSay();
+Public - DEBUG_CHANNEL which will show up like a script error allowing you to separate this info from chat, it is visible by every one
+and however it will not disrupt chat.
+
 THIS FILE IS HEREBY RELEASED UNDER THE Public Domain
 This script is released public domain, unlike other OC scripts for a specific and limited reason, because we want to encourage third party plugin creators to create for OpenCollar and use whatever permissions on their own work they see fit.  No portion of OpenCollar derived code may be used excepting this script,  without the accompanying GPLv2 license.
 -Authors Attribution-

--- a/src/spares/oc_debugger
+++ b/src/spares/oc_debugger
@@ -1,7 +1,7 @@
 /*
 This application is not recomended for regular users.
 
-This is a Basic debugger it manages messages fromt he script that don't always need to be seen in three categories
+This is a Basic debugger it manages messages from the script that don't always need to be seen in three categories
 Info - Basic information like the addons getting kicked for inactivity.
 Warning - Information about problems that won't break the collar but could cause instability.
 Errors - Information that Will or May cause the collar to break entirely.

--- a/src/spares/oc_debugger
+++ b/src/spares/oc_debugger
@@ -1,0 +1,196 @@
+/*
+THIS FILE IS HEREBY RELEASED UNDER THE Public Domain
+This script is released public domain, unlike other OC scripts for a specific and limited reason, because we want to encourage third party plugin creators to create for OpenCollar and use whatever permissions on their own work they see fit.  No portion of OpenCollar derived code may be used excepting this script,  without the accompanying GPLv2 license.
+-Authors Attribution-
+Phidoux (taya.maruti) - (july 2022)
+*/
+
+
+string g_sParentMenu = "Apps";
+string g_sSubMenu = "Debugger";
+
+
+//MESSAGE MAP
+integer CMD_OWNER = 500;
+integer CMD_WEARER = 503;
+integer REBOOT = -1000;
+
+integer MENUNAME_REQUEST = 3000;
+integer MENUNAME_RESPONSE = 3001;
+
+integer DIALOG = -9000;
+integer DIALOG_RESPONSE = -9001;
+integer DIALOG_TIMEOUT = -9002;
+integer DEBUG=DEBUG_CHANNEL;
+
+string UPMENU = "BACK";
+string b_sStatus;
+string b_sActive = "☒Active";
+string b_sInActive= "☐Active";
+string outType;
+string outChan;
+
+Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
+    key kMenuID = llGenerateKey();
+    llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
+
+    integer iIndex = llListFindList(g_lMenuIDs, [kID]);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    else g_lMenuIDs += [kID, kMenuID, sName];
+}
+
+Menu(key kID, integer iAuth) {
+    string sPrompt = "\n[Menu App]\n\nOutput Type:"+outType+"\nOutput Channel:"+outChan;
+    if(g_iDebug){
+        b_sStatus = b_sActive;
+    } else {
+        b_sStatus = b_sInActive;
+    }
+    list lButtons = [b_sStatus,"Error","Warn","Info","Public","Private"];
+    Dialog(kID, sPrompt, lButtons, [UPMENU], 0, iAuth, "Menu~Main");
+}
+
+UserCommand(integer iNum, string sStr, key kID) {
+    if (iNum<CMD_OWNER || iNum>CMD_WEARER){
+        return;
+    }
+    if (llSubStringIndex(llToLower(sStr),llToLower(g_sSubMenu)) && llToLower(sStr) != "menu "+llToLower(g_sSubMenu)){
+        return;
+    }
+    if (llToLower(sStr)==llToLower(g_sSubMenu) || llToLower(sStr) == "menu "+llToLower(g_sSubMenu)){
+         Menu(kID, iNum);
+    } else {
+    }
+}
+
+key g_kWearer;
+list g_lMenuIDs;
+integer g_iMenuStride;
+integer g_iDebug=FALSE;
+integer g_iOutputType = 2;
+integer g_iOutputForm;
+integer g_iTypeInfo = 0;
+integer g_iTypeWarn = 1;
+integer g_iTypeError = 2;
+integer g_iFormPublic   =0;
+integer g_iFormPrivate  =1;
+
+integer ALIVE = -55;
+integer READY = -56;
+integer STARTUP = -57;
+
+debug(string msg,integer oType){
+    if(oType == g_iFormPublic){
+        llSay(DEBUG_CHANNEL,msg);
+    }
+    if(oType == g_iFormPrivate){
+        llOwnerSay(msg);
+    }
+}
+
+default
+{
+    on_rez(integer iNum){
+        llMessageLinked(LINK_SET, ALIVE, llGetScriptName(),"");
+    }
+    state_entry(){
+        llMessageLinked(LINK_SET, ALIVE, llGetScriptName(),"");
+    }
+    link_message(integer iSender, integer iNum, string sStr, key kID){
+        if(iNum == REBOOT){
+            if(sStr == "reboot"){
+                llResetScript();
+            }
+        } else if(iNum == READY){
+            llMessageLinked(LINK_SET, ALIVE, llGetScriptName(), "");
+        } else if(iNum == STARTUP){
+            state active;
+        }
+    }
+}
+state active
+{
+    on_rez(integer t){
+        if(llGetOwner()!=g_kWearer) llResetScript();
+    }
+    state_entry()
+    {
+        g_kWearer = llGetOwner();
+        g_iDebug = FALSE;
+        outType="INFO";
+        g_iOutputType = g_iTypeInfo;
+        outChan="OwnerSay";
+        g_iOutputForm = g_iFormPrivate;
+    }
+    link_message(integer iSender,integer iNum,string sStr,key kID){
+        if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) UserCommand(iNum, sStr, kID);
+        else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
+            llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
+        else if(iNum == DIALOG_RESPONSE){
+            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
+            if(iMenuIndex!=-1){
+                string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                list lMenuParams = llParseString2List(sStr, ["|"],[]);
+                key kAv = llList2Key(lMenuParams,0);
+                string sMsg = llList2String(lMenuParams,1);
+                integer iAuth = llList2Integer(lMenuParams,3);
+                
+                if(sMenu == "Menu~Main"){
+                    if(sMsg == UPMENU){
+                        llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
+                    } else if(sMsg == b_sActive){
+                        g_iDebug = FALSE;
+                        Menu(kAv, iAuth);
+                    } else if(sMsg == b_sInActive){
+                        g_iDebug = TRUE;
+                        Menu(kAv, iAuth);
+                    } else if(sMsg == "Error"){
+                        outType = "Error";
+                        g_iOutputType = g_iTypeError;
+                        Menu(kAv, iAuth);
+                    } else if(sMsg == "Warn"){
+                        outType = "Warning";
+                        g_iOutputType = g_iTypeWarn;
+                        Menu(kAv, iAuth);
+                    } else if(sMsg == "Info"){
+                        outType = "Info";
+                        g_iOutputType = g_iTypeInfo;
+                        Menu(kAv, iAuth);
+                    } else if(sMsg == "Public"){
+                        outChan = "DEBUG_CHANNEL";
+                        g_iOutputForm = g_iFormPublic;
+                        Menu(kAv, iAuth);
+                    } else if(sMsg == "Private"){
+                        outChan = "OwnerSay";
+                        g_iOutputForm = g_iFormPrivate;
+                        Menu(kAv, iAuth);
+                    }
+                }
+            }
+        } else if (iNum == DIALOG_TIMEOUT) {
+            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
+            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+        }else if(iNum == DEBUG){
+            /*
+                input format from other scripts is as follows
+                Types: ERR,WRN,INFO
+                (type):(message)
+                message can be any thing preferably descriptive of the issue.
+            */
+            list lSettings = llParseString2List(sStr, [":"],[]);
+            string sToken = llList2String(lSettings,0);
+            string sVal = llList2String(lSettings,1);
+            if(sToken=="ERR"){
+                if(g_iDebug && g_iOutputType >= g_iTypeError){
+                    debug("Error:"+sVal,g_iOutputForm);
+                }
+                debug("Error:"+sVal,2);
+            } else if(sToken == "WRN" && g_iDebug && g_iOutputType >= g_iTypeWarn){
+                debug("Warning:"+sVal,g_iOutputForm);
+            } else if(sToken == "INFO" && g_iDebug && g_iOutputType >= g_iTypeInfo){
+                debug("Info:"+sVal,g_iOutputForm);
+            }
+        }
+    }
+}


### PR DESCRIPTION
For now i will place this as an addon I personally hope it becomes a core file at some point to manage output and debugging of the collar and all addons/plugins its a relatively simple output controller for creators so that you can get customized debug information, while taming the llOwnerSay and other outputs inside your builds so that they can be hidden away unless needed in a unified manner.