### PR TITLE
fix a few bugs and bring more inline with style

### DIFF
--- a/src/spares/oc_debugger
+++ b/src/spares/oc_debugger
@@ -1,31 +1,13 @@
 /*
-This application is not recomended for regular users.
-
-This is a Basic debugger it manages messages from the script that don't always need to be seen in three categories
-Info - Basic information like the addons getting kicked for inactivity.
-Warning - Information about problems that won't break the collar but could cause instability.
-Errors - Information that Will or May cause the collar to break entirely.
-
-by Default the system is inactive, and set to info.
-Errors are the only exception and get put in DEBUG_CHANNEL like normal script errors, as well as normal output you select.
-Errors also get displayed while the app is inactive.
-
-you get two options for output
-Private and Public
-Private - llOwnerSay();
-Public - DEBUG_CHANNEL which will show up like a script error allowing you to separate this info from chat, it is visible by every one
-and however it will not disrupt chat.
-
 THIS FILE IS HEREBY RELEASED UNDER THE Public Domain
 This script is released public domain, unlike other OC scripts for a specific and limited reason, because we want to encourage third party plugin creators to create for OpenCollar and use whatever permissions on their own work they see fit.  No portion of OpenCollar derived code may be used excepting this script,  without the accompanying GPLv2 license.
 -Authors Attribution-
 Phidoux (taya.maruti) - (july 2022)
 */
 
-
+string g_sVersion = "1.0";
 string g_sParentMenu = "Apps";
-string g_sSubMenu = "Debugger";
-
+string g_sSubMenu = "debugger";
 
 //MESSAGE MAP
 integer CMD_OWNER = 500;
@@ -34,6 +16,11 @@ integer REBOOT = -1000;
 
 integer MENUNAME_REQUEST = 3000;
 integer MENUNAME_RESPONSE = 3001;
+integer LM_SETTING_SAVE     = 2000; //scripts send messages on this channel to have settings saved, <string> must be in form of "token=value"
+integer LM_SETTING_REQUEST  = 2001; //when startup, scripts send requests for settings on this channel
+integer LM_SETTING_RESPONSE = 2002; //the settings script sends responses on this channel
+integer LM_SETTING_DELETE   = 2003; //delete token from settings
+//integer LM_SETTING_EMPTY    = 2004; //sent when a token has no value
 
 integer DIALOG = -9000;
 integer DIALOG_RESPONSE = -9001;
@@ -41,9 +28,11 @@ integer DIALOG_TIMEOUT = -9002;
 integer DEBUG=DEBUG_CHANNEL;
 
 string UPMENU = "BACK";
+list g_lCheckBoxes = ["☐","☑"];
+list b_lCheckBoxes;
 string b_sStatus;
-string b_sActive = "☒Active";
-string b_sInActive= "☐Active";
+string b_sActive;
+string d_sActive= "Active";
 string outType;
 string outChan;
 
@@ -57,21 +46,21 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
 }
 
 Menu(key kID, integer iAuth) {
-    string sPrompt = "\n[Menu App]\n\nOutput Type:"+outType+"\nOutput Channel:"+outChan;
-    if(g_iDebug){
-        b_sStatus = b_sActive;
+    string sPrompt = "\n["+g_sSubMenu+"]\n\nOutput Type:"+outType+"\nOutput Channel:"+outChan;
+    if( b_lCheckBoxes != [] ) {
+        b_sActive = llList2String(b_lCheckBoxes,g_iDebug)+d_sActive;
     } else {
-        b_sStatus = b_sInActive;
+        b_sActive = llList2String(g_lCheckBoxes,g_iDebug)+d_sActive;
     }
     list lButtons = [b_sStatus,"Error","Warn","Info","Public","Private"];
     Dialog(kID, sPrompt, lButtons, [UPMENU], 0, iAuth, "Menu~Main");
 }
 
 UserCommand(integer iNum, string sStr, key kID) {
-    if (iNum<CMD_OWNER || iNum>CMD_WEARER){
+    if (iNum<CMD_OWNER || iNum>CMD_WEARER) {
         return;
     }
-    if (llSubStringIndex(llToLower(sStr),llToLower(g_sSubMenu)) && llToLower(sStr) != "menu "+llToLower(g_sSubMenu)){
+    if (llSubStringIndex(llToLower(sStr),llToLower(g_sSubMenu)) && llToLower(sStr) != "menu "+llToLower(g_sSubMenu)) {
         return;
     }
     if (llToLower(sStr)==llToLower(g_sSubMenu) || llToLower(sStr) == "menu "+llToLower(g_sSubMenu)){
@@ -83,69 +72,77 @@ UserCommand(integer iNum, string sStr, key kID) {
 key g_kWearer;
 list g_lMenuIDs;
 integer g_iMenuStride;
-integer g_iDebug=FALSE;
+integer g_iDebug=TRUE;
 integer g_iOutputType = 2;
 integer g_iOutputForm;
 integer g_iTypeInfo = 0;
 integer g_iTypeWarn = 1;
 integer g_iTypeError = 2;
-integer g_iFormPublic   =0;
-integer g_iFormPrivate  =1;
+integer g_iFormPublic =0;
+integer g_iFormPrivate =1;
 
 integer ALIVE = -55;
 integer READY = -56;
 integer STARTUP = -57;
 
+integer first_run = TRUE;
+
 debug(string msg,integer oType){
     if(oType == g_iFormPublic){
         llSay(DEBUG_CHANNEL,msg);
-    }
-    if(oType == g_iFormPrivate){
+    } else if(oType == g_iFormPrivate){
         llOwnerSay(msg);
     }
 }
 
 default
 {
-    on_rez(integer iNum){
+    on_rez(integer iNum) {
         llMessageLinked(LINK_SET, ALIVE, llGetScriptName(),"");
     }
-    state_entry(){
+    state_entry() {
         llMessageLinked(LINK_SET, ALIVE, llGetScriptName(),"");
     }
-    link_message(integer iSender, integer iNum, string sStr, key kID){
-        if(iNum == REBOOT){
-            if(sStr == "reboot"){
+    link_message(integer iSender, integer iNum, string sStr, key kID) {
+        if(iNum == REBOOT) {
+            if(sStr == "reboot") {
                 llResetScript();
             }
-        } else if(iNum == READY){
+        } else if(iNum == READY) {
             llMessageLinked(LINK_SET, ALIVE, llGetScriptName(), "");
-        } else if(iNum == STARTUP){
+        } else if(iNum == STARTUP) {
             state active;
         }
     }
 }
-state active
-{
-    on_rez(integer t){
-        if(llGetOwner()!=g_kWearer) llResetScript();
+state active {
+    on_rez(integer t) {
+        if(llGetOwner()!=g_kWearer) {
+            //llResetScript();
+            state default;
+        }
     }
-    state_entry()
-    {
+    state_entry() {
+        if( first_run ){
+            debug("this script is running for the first time since restart we need to create persitence setting for status!",0);
+            first_run = FALSE;
+            llMessageLinked(LINK_SET, LM_SETTING_SAVE,"global_debugger="+(string)g_iDebug,"");
+        }
+        llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "global","");
         g_kWearer = llGetOwner();
-        g_iDebug = FALSE;
-        outType="INFO";
+        outType="Info";
         g_iOutputType = g_iTypeInfo;
         outChan="OwnerSay";
         g_iOutputForm = g_iFormPrivate;
     }
-    link_message(integer iSender,integer iNum,string sStr,key kID){
-        if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) UserCommand(iNum, sStr, kID);
-        else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
+    link_message(integer iSender,integer iNum,string sStr,key kID) {
+        if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) {
+            UserCommand(iNum, sStr, kID);
+        } else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu) { 
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
-        else if(iNum == DIALOG_RESPONSE){
+        } else if(iNum == DIALOG_RESPONSE) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if(iMenuIndex!=-1){
+            if(iMenuIndex!=-1) {
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
                 g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
@@ -153,32 +150,34 @@ state active
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
                 
-                if(sMenu == "Menu~Main"){
+                if(sMenu == "Menu~Main") {
                     if(sMsg == UPMENU){
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     } else if(sMsg == b_sActive){
-                        g_iDebug = FALSE;
+                        if(g_iDebug) {
+                            g_iDebug = FALSE;
+                        } else {
+                            g_iDebug = TRUE;
+                        }
+                        llMessageLinked(LINK_SET, LM_SETTING_SAVE,"global_debugger="+(string)g_iDebug,"");
                         Menu(kAv, iAuth);
-                    } else if(sMsg == b_sInActive){
-                        g_iDebug = TRUE;
-                        Menu(kAv, iAuth);
-                    } else if(sMsg == "Error"){
+                    } else if(sMsg == "Error") {
                         outType = "Error";
                         g_iOutputType = g_iTypeError;
                         Menu(kAv, iAuth);
-                    } else if(sMsg == "Warn"){
+                    } else if(sMsg == "Warn") {
                         outType = "Warning";
                         g_iOutputType = g_iTypeWarn;
                         Menu(kAv, iAuth);
-                    } else if(sMsg == "Info"){
+                    } else if(sMsg == "Info") {
                         outType = "Info";
                         g_iOutputType = g_iTypeInfo;
                         Menu(kAv, iAuth);
-                    } else if(sMsg == "Public"){
+                    } else if(sMsg == "Public") {
                         outChan = "DEBUG_CHANNEL";
                         g_iOutputForm = g_iFormPublic;
                         Menu(kAv, iAuth);
-                    } else if(sMsg == "Private"){
+                    } else if(sMsg == "Private") {
                         outChan = "OwnerSay";
                         g_iOutputForm = g_iFormPrivate;
                         Menu(kAv, iAuth);
@@ -199,7 +198,7 @@ state active
             string sToken = llList2String(lSettings,0);
             string sVal = llList2String(lSettings,1);
             if(sToken=="ERR"){
-                if(g_iDebug && g_iOutputType >= g_iTypeError){
+                if(g_iDebug && g_iOutputType >= g_iTypeError) {
                     debug("Error:"+sVal,g_iOutputForm);
                 }
                 debug("Error:"+sVal,2);
@@ -207,6 +206,32 @@ state active
                 debug("Warning:"+sVal,g_iOutputForm);
             } else if(sToken == "INFO" && g_iDebug && g_iOutputType >= g_iTypeInfo){
                 debug("Info:"+sVal,g_iOutputForm);
+            }
+        } else if (iNum == LM_SETTING_RESPONSE) {
+            list lPar     = llParseString2List(sStr, ["_","="], []);
+            string sToken = llList2String(lPar, 0);
+            string sVar   = llList2String(lPar, 1);
+            string sVal   = llList2String(lPar, 2);
+            if( sToken == "global") {
+                if( sVar == "checkboxes") {
+                    debug("recived the checkboxes "+sVal,0);
+                    b_lCheckBoxes = llParseString2List(sVal,[","],[]);
+                }
+                if( sVar == "debugger"){
+                    debug("updating debugger status!",0);
+                    g_iDebug = (integer)sVal;
+                }
+            }
+        } else if (iNum == LM_SETTING_DELETE) {
+            // This is recieved back from settings when a setting is deleted
+            list lPar     = llParseString2List(sStr, ["_","="], []);
+            string sToken = llList2String(lPar, 0);
+            string sVar   = llList2String(lPar, 1);
+            if(sToken == "global"){
+                if(sVar == "debugger"){
+                    debug("debugger status has been deleted from settings this could cause issues, attempting to reassert!",1);
+                    llMessageLinked(LINK_SET, LM_SETTING_SAVE,"global_debugger="+(string)g_iDebug,"");
+                }
             }
         }
     }


### PR DESCRIPTION
this update is to fix a few issues with persistence and clean up the code a little 

0) set the debugger to default active.
1) adding visual styles like default collar check boxes with a fall back check box style,
2) created a persistent global setting for debugger status to survive relogs and teleports, 
3) remove llReset on rez while active status has been achieve to help persistence instead we return to default,
4) cleaned up the code to be more inline with oc style guide recommends and requirements