### PR TITLE
oc_extensions fixes

### DIFF
--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -46,6 +46,7 @@ Medea Destiny -
     Feb2021     -   SetAllExes triggered on RLV_REFRESH / RLV_ON was saving values, causing exception
                     settings to be restored to defaults if trigged before settings are received.
                     (fixes #740, #720, #719)
+                    
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -46,7 +46,10 @@ Medea Destiny -
     Feb2021     -   SetAllExes triggered on RLV_REFRESH / RLV_ON was saving values, causing exception
                     settings to be restored to defaults if trigged before settings are received.
                     (fixes #740, #720, #719)
-                    
+ 
+ 
+Krysten Minx -
+   May2022      - Added check for valid UUID when setting custom exception
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";
@@ -588,12 +591,15 @@ state active
                     g_sTmpExceptionName=sMsg;
                     MenuAddCustomExceptionID(kAv,iAuth);
                 } else if(sMenu == "Exceptions~AddCustomID"){
-                    g_kTmpExceptionID = (key)sMsg;
-                    llMessageLinked(LINK_SET,NOTIFY,"0Adding exception..", kAv);
-                    g_lCustomExceptions += [g_sTmpExceptionName,g_kTmpExceptionID,0];
-                    
-                    Save(SAVE_CUSTOM);
-                    MenuSetExceptions(kAv, iAuth, "Custom");
+                    if ((key)sMsg) { // true if valid UUID, false if not
+                         g_kTmpExceptionID = (key)sMsg;
+                         llMessageLinked(LINK_SET,NOTIFY,"0Adding exception..", kAv);
+                         g_lCustomExceptions += [g_sTmpExceptionName,g_kTmpExceptionID,0];
+                         Save(SAVE_CUSTOM);
+                         MenuSetExceptions(kAv, iAuth, "Custom");
+                    } else {
+                         llMessageLinked(LINK_SET,NOTIFY,"0Invalid UUID "+sMsg, kAv);
+                    }
                 } else if (sMenu == "Exceptions~Set") {
                     if (sMsg == UPMENU) MenuExceptions(kAv,iAuth);
                     else {

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -41,7 +41,7 @@ Medea Destiny -
                     automatically for owners. 
                 -   Added explanatory text to exceptions and force sit menus
                 -   Renamed Refuse TP to Force TP to reflect what the button actually does.                  
-
+    Dec2021     -   Fixed filtering of unsit - > sit unsit for chat command and remote (issue #703 )
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";
@@ -401,6 +401,7 @@ integer g_iLastSitAuth = 599;
 UserCommand(integer iNum, string sStr, key kID) {
     if (iNum<CMD_OWNER || iNum>CMD_EVERYONE) return;
     sStr=llToLower(sStr);
+    if(sStr=="unsit") sStr="sit unsit";
    // if ((llSubStringIndex(sStr,"exceptions") && sStr != "menu "+g_sSubMenu1) || (llSubStringIndex(sStr,"exceptions") && sStr != "menu "+g_sSubMenu2)) return;
     if (sStr=="sit" || sStr == "menu "+llToLower(g_sSubMenu1)) MenuForceSit(kID, iNum);
     else if (sStr=="exceptions" || sStr == "menu "+llToLower(g_sSubMenu2)) MenuExceptions(kID,iNum);
@@ -423,10 +424,6 @@ UserCommand(integer iNum, string sStr, key kID) {
     else { 
         string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
         string sChangekey = llList2String(llParseString2List(sStr, [" "], []),1);
-        if(sChangetype=="unsit")  {
-            sChangetype="sit";
-            sChangekey="unsit";
-        }
         if (sChangetype == "sit") {
             if ((sChangekey == "[unsit]" || sChangekey == "unsit")) {
                 if(iNum> g_iLastSitAuth ) {

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -42,6 +42,7 @@ Medea Destiny -
                 -   Added explanatory text to exceptions and force sit menus
                 -   Renamed Refuse TP to Force TP to reflect what the button actually does.                  
     Dec2021     -   Fixed filtering of unsit - > sit unsit for chat command and remote (issue #703 )
+                -   Fix to disengaging strict sit when disabled via menu when already sitting.
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";
@@ -626,6 +627,7 @@ state active
                             MenuForceSit(kAv,iAuth);
                         } else{
                             g_iStrictSit=1-g_iStrictSit;
+                            if(!g_iStrictSit) llMessageLinked(LINK_SET,RLV_CMD,"unsit=y","strictsit");
                             llMessageLinked(LINK_SET, LM_SETTING_SAVE, "rlvext_strict="+(string)g_iStrictSit, "");
                             MenuForceSit(kAv,iAuth);
                         }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -43,6 +43,9 @@ Medea Destiny -
                 -   Renamed Refuse TP to Force TP to reflect what the button actually does.                  
     Dec2021     -   Fixed filtering of unsit - > sit unsit for chat command and remote (issue #703 )
                 -   Fix to disengaging strict sit when disabled via menu when already sitting.
+    Feb2021     -   SetAllExes triggered on RLV_REFRESH / RLV_ON was saving values, causing exception
+                    settings to be restored to defaults if trigged before settings are received.
+                    (fixes #740, #720, #719)
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";
@@ -827,7 +830,7 @@ state active
             g_iRLV = FALSE;
         } else if (iNum == RLV_REFRESH || iNum == RLV_ON) {
             g_iRLV = TRUE;
-            SetAllExes(FALSE,EX_TYPE_OWNER|EX_TYPE_TRUSTED|EX_TYPE_CUSTOM,TRUE);
+            SetAllExes(FALSE,EX_TYPE_OWNER|EX_TYPE_TRUSTED|EX_TYPE_CUSTOM,FALSE);
             SetMuffle(g_bMuffle);
             llSleep(1);
             llMessageLinked(LINK_SET,LINK_CMD_RESTDATA,"MinCamDist="+(string)g_fMinCamDist,kID);


### PR DESCRIPTION
Fix to disengaging strict sit when disabled via menu when already sitting.

Fix to SetAllExes triggering on RLV_REFRESH / RLV_ON  causing values to be saved,  which could cause exception settings to be restored to defaults if trigged before settings are received. Fixes #740, #720, #719