### PR TITLE
Infinite loop in oc_api.lsl #819

### DIFF
--- a/src/collar/oc_api.lsl
+++ b/src/collar/oc_api.lsl
@@ -456,10 +456,9 @@ state active
         g_kWearer = llGetOwner();
         g_sPrefix = llToLower(llGetSubString(llKey2Name(llGetOwner()),0,1));
         // make the API Channel be per user
-        while(g_iInterfaceChannel==0){
-            g_iInterfaceChannel = (integer)("0x" + llGetSubString(g_kWearer,30,-1));
-            if (g_iInterfaceChannel > 0) g_iInterfaceChannel = -g_iInterfaceChannel;
-        }
+        g_iInterfaceChannel = (integer)("0x" + llGetSubString(g_kWearer,30,-1));
+        if (g_iInterfaceChannel == 0) { g_iInterfaceChannel = -83579; }
+        if (g_iInterfaceChannel > 0) { g_iInterfaceChannel = -g_iInterfaceChannel; }
         llListen(g_iInterfaceChannel, "","","");
         llSleep(0.5);
         llRegionSayTo(g_kWearer, g_iInterfaceChannel, "OpenCollar=Yes");


### PR DESCRIPTION
Infinite loop in oc_api.lsl https://github.com/OpenCollarTeam/OpenCollar/issues/819

Changed to an if statement, no chance of an infinite loop. Statically assigning channel -83579 to any user who's UUID ends with *000000

Everything looks right with this pull request. let me know if I did something wrong.