### PR TITLE
make core folder only acessable to listed #855

### DIFF
--- a/src/Apps/oc_outfits.lsl
+++ b/src/Apps/oc_outfits.lsl
@@ -418,6 +418,10 @@ state active
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     }
                     else if(sMsg == TickBox(g_iLockCore, "Lock Core")){
+                        if(iAuth != CMD_OWNER || kID != g_kWearer) {
+                           llMessageLinked(LINK_SET,NOTIFY, "0%NOACCESS% to core", kID);
+                           return;
+                        }
                         g_iLockCore=1-g_iLockCore;
                         llSetTimerEvent(120);
                         Commit();

--- a/src/Apps/oc_outfits.lsl
+++ b/src/Apps/oc_outfits.lsl
@@ -150,7 +150,7 @@ FolderBrowser (key kID, integer iAuth){
 }
 
 CoreBrowser(key kID, integer iAuth){
-    if(iAuth != CMD_OWNER || iAuth != CMD_WEARER) {
+    if(iAuth != CMD_OWNER || kID != g_kWearer) {
         llMessageLinked(LINK_SET,NOTIFY, "0%NOACCESS% to core", kID);
         return;
     }

--- a/src/Apps/oc_outfits.lsl
+++ b/src/Apps/oc_outfits.lsl
@@ -150,6 +150,10 @@ FolderBrowser (key kID, integer iAuth){
 }
 
 CoreBrowser(key kID, integer iAuth){
+    if(iAuth <= CMD_OWNER && iAuth >= CMD_WEARER) {
+        llMessageLinked(LINK_SET,NOTIFY, "0%NOACCESS% to core", kID);
+        return;
+    }
     g_sPath = GetOutfitSystem(TRUE);
     g_kListenTo = kID;
     g_iListenToAuth = iAuth;

--- a/src/Apps/oc_outfits.lsl
+++ b/src/Apps/oc_outfits.lsl
@@ -150,7 +150,7 @@ FolderBrowser (key kID, integer iAuth){
 }
 
 CoreBrowser(key kID, integer iAuth){
-    if(iAuth <= CMD_OWNER && iAuth >= CMD_WEARER) {
+    if(iAuth != CMD_OWNER || iAuth != CMD_WEARER) {
         llMessageLinked(LINK_SET,NOTIFY, "0%NOACCESS% to core", kID);
         return;
     }

--- a/src/Apps/oc_outfits.lsl
+++ b/src/Apps/oc_outfits.lsl
@@ -150,7 +150,7 @@ FolderBrowser (key kID, integer iAuth){
 }
 
 CoreBrowser(key kID, integer iAuth){
-    if(iAuth != CMD_OWNER || kID != g_kWearer) {
+    if(iAuth != CMD_OWNER && kID != g_kWearer) {
         llMessageLinked(LINK_SET,NOTIFY, "0%NOACCESS% to core", kID);
         return;
     }
@@ -418,7 +418,7 @@ state active
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     }
                     else if(sMsg == TickBox(g_iLockCore, "Lock Core")){
-                        if(iAuth != CMD_OWNER || kID != g_kWearer) {
+                        if(iAuth != CMD_OWNER && kID != g_kWearer) {
                            llMessageLinked(LINK_SET,NOTIFY, "0%NOACCESS% to core", kID);
                            return;
                         }


### PR DESCRIPTION
this simple change would prevent any one not on trusted or owners list from accessing core folder and changing a persons avatar or folder locks.

only merge if its decided in the poll that this is a desired 
#855 