### PR TITLE
add feature custom root paths

### DIFF
--- a/src/collar/oc_folders.lsl
+++ b/src/collar/oc_folders.lsl
@@ -654,7 +654,7 @@ state active
                             list lData = llParseString2List(sData,["/"],[]);
                             sData = llList2String(lData,llGetListLength(lData));
                             // now create a button list
-                            if(llGetSubString(sData,0,0) == "~" || llGetSubString(sData,0,0) == "."){
+                            if(llGetSubString(sData,0,0) == "~"){
                                 // remove the Tidle
                                 sData = llDeleteSubString(sData,0,0);
                             }
@@ -677,7 +677,7 @@ state active
                             */
                             g_lRootsFolders += [sData];
                             // now create a button list
-                            if(llGetSubString(sData,0,0) == "~" || llGetSubString(sData,0,0) == "."){
+                            if(llGetSubString(sData,0,0) == "~"){
                                 // remove the Tidle
                                 sData = llDeleteSubString(sData,0,0);
                             }

--- a/src/collar/oc_folders.lsl
+++ b/src/collar/oc_folders.lsl
@@ -582,6 +582,7 @@ state active
                         } else if(ButtonLabel=="Default Root"){
                             if(g_lRootsFolders != []){
                                 g_iRoot=!g_iRoot;
+                                llMessageLinked(LINK_SET, LM_SETTING_SAVE, "folders_roots="+(string)g_iRoot,"");
                             }
                         } else if(Enabled){
                             // Disable flag
@@ -625,6 +626,8 @@ state active
                     g_iAccessBitSet=(integer)llList2String(lSettings,2);
                 } else if(llList2String(lSettings,1) =="hidetilde"){
                     g_iHideTilde=(integer)llList2String(lSettings,2);
+                } else if(llList2String(lSettings,1)=="roots"){
+                    g_iRoot=(integer)llList2String(lSettings,2);
                 }
                 
             }
@@ -654,7 +657,7 @@ state active
                             list lData = llParseString2List(sData,["/"],[]);
                             sData = llList2String(lData,llGetListLength(lData));
                             // now create a button list
-                            if(llGetSubString(sData,0,0) == "~"){
+                            if(llGetSubString(sData,0,0) == "~" || llGetSubString(sData,0,0) == "."){
                                 // remove the Tidle
                                 sData = llDeleteSubString(sData,0,0);
                             }
@@ -677,7 +680,7 @@ state active
                             */
                             g_lRootsFolders += [sData];
                             // now create a button list
-                            if(llGetSubString(sData,0,0) == "~"){
+                            if(llGetSubString(sData,0,0) == "~" || llGetSubString(sData,0,0) == "."){
                                 // remove the Tidle
                                 sData = llDeleteSubString(sData,0,0);
                             }


### PR DESCRIPTION
This update adds a special feature but allows oc_folders to behave as it normally does when the options are not used.
changes:
    1) folders can be defined as root with a note card list, each line of the note card can be used to define a path and button that will be added to the
    main menu buttons, and enable the ability to disable browse button under config defined as "Default root".
   2) disabling "Default root" removes browse from the menu and allows only the paths defined by the note card to be used.
   3) folders with (~) or (.)will have the leading character striped from the button label but still function.
   4) folders will have the first letter capitalzied for the button label for readability. 
   5) not tested you can define full folder paths this allows for folders nested inside other folders.