### PR TITLE
update version checcking for future.

### DIFF
--- a/src/collar/oc_core.lsl
+++ b/src/collar/oc_core.lsl
@@ -33,6 +33,10 @@ Medea (Medea Destiny)
                     And kAv == g_kWearer instead of iAuth == CMD_WEARER in meu dialog responses for:
                     + / - trusted / blacklist when wearer is permitted, displaying access list, print settings  
                     
+Phidoux (Taya.Maruti)
+   October 19 2022 - Modify the update version checking so the next versions only take into account 
+                     #.#.# instead of #.#.####.
+
 Stormed Darkshade (StormedStormy)
     March 2022  -   Added a button for reboot to help/about menu.  
 
@@ -376,8 +380,12 @@ Compare(string V1, string V2){
         UPDATE_AVAILABLE=FALSE;
         return;
     }
-    V1 = llDumpList2String(llParseString2List(V1, ["."],[]),"");
-    V2 = llDumpList2String(llParseString2List(V2, ["."],[]), "");
+    list lVer1 = llParseString2List(V1,["."],[]);
+    list lVer2 = llParseString2List(V2,["."],[]);
+    //V1 = llDumpList2String(llParseString2List(V1, ["."],[]),"");
+    V1 = llList2String(lVer1,0)+llList2String(lVer1,1)+llGetSubString(llList2String(lVer1,2),0,0);
+    //V2 = llDumpList2String(llParseString2List(V2, ["."],[]), "");
+    V2 = llList2String(lVer2,0)+llList2String(lVer2,1)+llGetSubString(llList2String(lVer2,2),0,0);
     integer iV1 = (integer)V1;
     integer iV2 = (integer)V2;
 


### PR DESCRIPTION
[14:42:06 PDT] ròan [Silkie Sabra]: updated the version and rezzed another collar but still no change to the collar text [14:42:29 PDT] ròan [Silkie Sabra]: something else has to change in oc_core? [14:44:26 PDT] taya Maruti: @luna:~/Documents/lsl/OpenCollar$ grep -r version.txt grep: .git/index: binary file matches
src/collar/oc_core.lsl:                g_kUpdateCheck = llHTTPRequest("https://raw.githubusercontent.com/OpenCollarTeam/OpenCollar/master/web/version.txt",[],"");
src/collar/oc_core.lsl:                if(g_iAmNewer)g_kCheckDev = llHTTPRequest("https://raw.githubusercontent.com/OpenCollarTeam/OpenCollar/master/web/dev_version.txt",[],"");

[14:44:45 PDT] taya Maruti: might need to do both sorry had to go afk for a moment [14:45:27 PDT] ròan [Silkie Sabra]: I did both
[14:46:55 PDT] taya Maruti: the rc versions i have are 8.2.2030 so it has to be newer or equal to that [14:47:40 PDT] taya Maruti: what ever you put to as the core version is what its checking against [14:49:16 PDT] ròan [Silkie Sabra]: 8.2.2000
[14:50:04 PDT] ròan [Silkie Sabra]: the integers in the third decimal place are separate placeholders, not sequential, like a library decimal system [14:51:39 PDT] taya Maruti: 8.2.2000 is less than 8.2.2030 if you are are using one of the rc versions [14:53:58 PDT] taya Maruti: line 372 is the function that breaks up the version string and compares the numbers [14:54:43 PDT] ròan [Silkie Sabra]: then the system we devised for version naming won't work [14:54:52 PDT] taya Maruti: it converts 8.2.2000 to 822000 and compares it with 822030 [14:55:10 PDT] taya Maruti: atleast with my colar versions [14:55:12 PDT] ròan [Silkie Sabra]: look at the top of oc_core where it gives a legend for versioning [14:55:20 PDT] taya Maruti: the release should be higher or equal to the rc versions [14:55:43 PDT] taya Maruti: yes i see 8.2.2000
[14:55:56 PDT] ròan [Silkie Sabra]: that's not going to work if the script is converting those places to simple numbers [14:56:08 PDT] ròan [Silkie Sabra]: look at the text explaining that [14:56:28 PDT] taya Maruti: Compare(string V1, string V2){
    NEW_VERSION=V2;

    if(V1==V2){
        UPDATE_AVAILABLE=FALSE;
        return;
    }
    V1 = llDumpList2String(llParseString2List(V1, ["."],[]),"");
    V2 = llDumpList2String(llParseString2List(V2, ["."],[]), "");
    integer iV1 = (integer)V1;
    integer iV2 = (integer)V2;

    if(iV1 < iV2){
        UPDATE_AVAILABLE=TRUE;
        g_iAmNewer=FALSE;
    } else if(iV1 == iV2) return;
    else if(iV1 > iV2){
        UPDATE_AVAILABLE=FALSE;
        g_iAmNewer=TRUE;

       // llSetText("", <1,0,0>,1); //Not sure what this is for, but seems unnecessary? Commented out unless someone finds a reason for>
    }
}

[14:56:36 PDT] ròan [Silkie Sabra]: LEGEND: Major.Minor.Build RC Beta Alpha
[14:57:04 PDT] ròan [Silkie Sabra]: so 8.2.2030 meant 8.2.2 beta 3
[14:57:33 PDT] taya Maruti: llparse string needs to instead of being dumped split into llList2String(parsed,0)+llList2String(parsed,1); in order for it to not use the third spot
[14:57:52 PDT] taya Maruti: that code just removes the . as it is
[14:58:30 PDT] taya Maruti: but then you would also have to change legacy collars
[14:58:49 PDT] taya Maruti: which makes the update process all that much more complicatd
[14:58:53 PDT] ròan [Silkie Sabra]: might be easier to change the way the versioning is supposed to read
[15:00:12 PDT] taya Maruti: what ever you have to do you either have to change the code to match what you want or you have to work with the code as it is and change your thinking
[15:00:26 PDT] taya Maruti: now is the time to do that
[15:00:45 PDT] taya Maruti: we can still patch the versioning code in the current version so that the next update works the way you want it
[15:01:54 PDT] taya Maruti: llList2String(parsed,0)+llList2String(parsed,1)+llGetSubString(llList2String(parsed,2),0,0);
[15:01:59 PDT] taya Maruti: that would get 8.2.2
[15:02:29 PDT] taya Maruti: or 822 for the check
[15:03:55 PDT] taya Maruti: however the changes made should work for all collars below 822000 or 8.2.2000 in context
[15:04:09 PDT] taya Maruti: most of the stable releases
[15:04:18 PDT] taya Maruti: it won't update the rc candidates
[15:05:58 PDT] ròan [Silkie Sabra]: can you make a pr? because my brain is fried and i think Medea needs to make the call
[15:09:30 PDT] taya Maruti: the only major qustion is should i just go a head and pr as master or do we need a new quarter
[15:10:17 PDT] ròan [Silkie Sabra]: we need this in the master, before 8.2.2 can go out to the vendor
[15:10:36 PDT] ròan [Silkie Sabra]: then we'll make a new branch for the next version but i don't think it will specify quarter
[15:10:56 PDT] ròan [Silkie Sabra]: because we're in quarter 4 now and just managed to get q1 into the can