### PR TITLE
8.2.3

### DIFF
--- a/src/collar/oc_addons.lsl
+++ b/src/collar/oc_addons.lsl
@@ -9,6 +9,14 @@ Medea (medea.destiny)
     Sept 2021           -   Provided auth failure mode for menu. Insufficient auth now
                             provides suitable notification to user and respawns main menu. 
                             Fixes issue #665   
+
+KristenMynx
+    Dec 2021            -   Fix timeout removal stride
+    May 2022            -   Fix offline removal stride
+                        -   Reduce chatter
+    Jun 2022            -   Reduce chatter more
+    
+    
     
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
@@ -18,7 +26,7 @@ https://github.com/OpenCollarTeam/OpenCollar
 string g_sParentMenu = "Main";
 string g_sSubMenu = "Addons";
 
-string COLLAR_VERSION = "8.1.0000";
+string COLLAR_VERSION = "8.2.3000";
 
 string Auth2Str(integer iAuth){
     if(iAuth == CMD_OWNER)return "Owner";
@@ -550,3 +558,4 @@ state active
         //llOwnerSay(llDumpList2String([iSender,iNum,sStr,kID],"^"));
     }
 }
+

--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -5,15 +5,21 @@ Copyright 2021
 : Contributors :
 
 Aria (Tashia Redrose)
-    * July 2020         - Rewrote oc_anim
-    * Dec 2020          - Fix bug where animations were not treated case insensitive, and where animations with a space in the name could not be played by chat command or menu button
-    * Feb 2021          - Fix Public Access
+    July 2020 - Rewrote oc_anim
+    Dec 2020  - Fix bug where animations were not treated case insensitive, and where animations
+                     with a space in the name could not be played by chat command or menu button
+    Feb 2021  - Fix Public Access
     
 Felkami (Caraway Ohmai)
-    * Dec 2020          - Fixed #456, #462, #461, added LockMeister AO suppress
+    Dec 2020  - Fixed #456, #462, #461, added LockMeister AO suppress
 
 et al.
 
+K9K8E
+    Apr 2022    - Remove CONTROL_ML_LBUTTON from take controls to allow left mouse in mouselook.
+
+Tayaphidoux
+    Jun 2022    - Restore AO pause functionality
 
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -726,3 +732,4 @@ state inUpdate{
         }
     }
 }
+

--- a/src/collar/oc_bookmarks.lsl
+++ b/src/collar/oc_bookmarks.lsl
@@ -10,7 +10,7 @@ Medea Destiny -
 
 */
 
-string g_sScriptVersion = "8.1";
+string g_sScriptVersion = "8.2";
 integer LINK_CMD_DEBUG=1999;
 DebugOutput(key kID, list ITEMS){
     integer i=0;
@@ -600,3 +600,4 @@ state active
         if(iChange & CHANGED_OWNER)  llResetScript();
     }
 }
+

--- a/src/collar/oc_core.lsl
+++ b/src/collar/oc_core.lsl
@@ -32,7 +32,7 @@ Medea (Medea Destiny)
                     Safeword report, verbosity level, locking
                     And kAv == g_kWearer instead of iAuth == CMD_WEARER in meu dialog responses for:
                     + / - trusted / blacklist when wearer is permitted, displaying access list, print settings  
-    Oct 2022    -   Fix for full version>beta version checking 
+    Oct 2022    -   Fix for full version>beta version checking. Added menu text to clarify versioning for beta users.
                     
 Stormed Darkshade (StormedStormy)
     March 2022  -   Added a button for reboot to help/about menu.  
@@ -52,6 +52,7 @@ string COLLAR_VERSION = "8.2.3000"; // Provide enough room
 integer UPDATE_AVAILABLE=FALSE;
 string NEW_VERSION = "";
 integer g_iAmNewer=FALSE;
+integer g_iIsBeta;
 integer g_iChannel=1;
 string g_sPrefix;
 
@@ -158,6 +159,7 @@ Menu(key kID, integer iAuth) {
 
     if(UPDATE_AVAILABLE ) sPrompt += "\n\nUPDATE AVAILABLE: Your version is: "+COLLAR_VERSION+", The current release version is: "+NEW_VERSION;
     if(g_iAmNewer)sPrompt+="\n\nYour collar version is newer than the public release. This may happen if you are using a beta or pre-release copy.\nNote: Pre-Releases may have bugs. Ensure you report any bugs to [https://github.com/OpenCollarTeam/OpenCollar Github]";
+    if(g_iIsBeta)sPrompt+="\n(The last 3 digits indicate a pre-release version, which is superseded by 000 for a release version).";
 
     if(g_iWelded)sPrompt+="\n\n* The Collar is Welded by secondlife:///app/agent/"+(string)g_kWeldBy+"/about *";
     if(iAuth==CMD_OWNER && g_iLocked && !g_iWelded)lButtons+=["Weld"];
@@ -371,8 +373,9 @@ list g_lMenuIDs;
 integer g_iMenuStride;
 integer g_iLocked=FALSE;
 Compare(string V1, string V2){
+    V2=llStringTrim(V2,STRING_TRIM);
     NEW_VERSION=V2;
-
+    if(llGetSubString(V1,-3,-1)!="000") g_iIsBeta=TRUE;
     if(V1==V2){
         UPDATE_AVAILABLE=FALSE;
         return;

--- a/src/collar/oc_core.lsl
+++ b/src/collar/oc_core.lsl
@@ -32,12 +32,13 @@ Medea (Medea Destiny)
                     Safeword report, verbosity level, locking
                     And kAv == g_kWearer instead of iAuth == CMD_WEARER in meu dialog responses for:
                     + / - trusted / blacklist when wearer is permitted, displaying access list, print settings  
+    Oct 2022    -   Fix for full version>beta version checking 
                     
 Stormed Darkshade (StormedStormy)
     March 2022  -   Added a button for reboot to help/about menu.  
 
 Yosty7B3
-    Nov 2022  - Removed Setor() and bool() functions for streamlining.
+    Nov 2022  -     Removed Setor() and bool() functions for streamlining.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
 */
@@ -46,7 +47,7 @@ integer NOTIFY_OWNERS=1003;
 
 //string g_sParentMenu = "";
 string g_sSubMenu = "Main";
-string COLLAR_VERSION = "8.2.2000"; // Provide enough room
+string COLLAR_VERSION = "8.2.3000"; // Provide enough room
 // LEGEND: Major.Minor.Build RC Beta Alpha
 integer UPDATE_AVAILABLE=FALSE;
 string NEW_VERSION = "";
@@ -386,6 +387,11 @@ Compare(string V1, string V2){
         g_iAmNewer=FALSE;
     } else if(iV1 == iV2) return;
     else if(iV1 > iV2){
+        if(llGetSubString(V2,-3,-1)=="000" && llGetSubString(V1,0,-4)==llGetSubString(V2,0,-4)){
+            UPDATE_AVAILABLE=TRUE;
+            g_iAmNewer=FALSE;
+            return;
+        }
         UPDATE_AVAILABLE=FALSE;
         g_iAmNewer=TRUE;
 

--- a/src/collar/oc_rlvsys.lsl
+++ b/src/collar/oc_rlvsys.lsl
@@ -11,14 +11,14 @@ Medea Destiny   -
                         perform the function, and then reset the restriction, but that's a lot of hassle. This performs the 
                         function automatically. Operator and wearer are notified of restrictions that have been temporarily 
                         restricted to avoid being misled that a restriciton is not present.
-        Aug 2022    -   Ensure applyrem() restores a detach=n when the collar is locked, otherwise new methodology with relay would cause a 
-                        locked collar to unlock when there are no more relay sources. Fix for issue #842
+        Aug 2022    -   Ensure applyrem() restores a detach=n when the collar is locked, otherwise new methodology with relay 
+                        would cause a locked collar to unlock when there are no more relay sources. Fix for issue #842
 Kristen Mynx -
         May 2022 - Removed DO_RLV_REFRESH and recheck_lock timer.   Both of these were only used by
         the relay, which is being changed at the same time.  Check the comments in oc_relay.
 */
 
-string g_sScriptVersion = "8.1";
+string g_sScriptVersion = "8.2";
 integer g_iRLVOn = TRUE;
 integer g_iRLVOff = FALSE;
 integer g_iViewerCheck = FALSE;
@@ -752,3 +752,4 @@ state inUpdate{
         }
     }
 }
+

--- a/src/collar/oc_rlvsys.lsl
+++ b/src/collar/oc_rlvsys.lsl
@@ -13,6 +13,7 @@ Medea Destiny   -
                         restricted to avoid being misled that a restriciton is not present.
         Aug 2022    -   Ensure applyrem() restores a detach=n when the collar is locked, otherwise new methodology with relay 
                         would cause a locked collar to unlock when there are no more relay sources. Fix for issue #842
+        Oct 2022    -   Changed "RLV ready!" notification to "RLV active!" to avoid confusion during boot process.
 Kristen Mynx -
         May 2022 - Removed DO_RLV_REFRESH and recheck_lock timer.   Both of these were only used by
         the relay, which is being changed at the same time.  Check the comments in oc_relay.
@@ -688,7 +689,7 @@ state active
                     if ((key)kSource) llShout(RELAY_CHANNEL,"ping,"+(string)kSource+",ping,ping");
                     else rebakeSourceRestrictions(kSource);  //reapply collar's restrictions here
                 }
-                if (!llGetStartParameter()) llMessageLinked(LINK_SET,NOTIFY,"0"+"RLV ready!",g_kWearer);
+                if (!llGetStartParameter()) llMessageLinked(LINK_SET,NOTIFY,"0"+"RLV active!",g_kWearer);
             }
         } else {
             if (g_iCheckCount++ < g_iMaxViewerChecks) {


### PR DESCRIPTION
Various tweaks to update to 8.2.3 emergency release

What happened? We released 8.2.2 with 8.2.1 scripts in it. Rather than re-releasing with the same version number, which has the potential to cause confusion, we need to bump build to 8.2.3.  This PR is to bring master in line with the updates I've done inworld to the updater to make 8.2.3. It contains a small number of minor modifications where we've omitted a change to internal script numbers for debug, or haven't added in changelog notices. There's also a version check tweak, for which see below.

 oc_addons: bump version number, add omitted credits
oc_anim: add omitted credits
oc_bookmarks: bump version number
oc_core: bump version number, fix for versioning issue (see below)
oc_rlvsys: bump version number, change "RLV ready!" message to "RLV active!" to avoid confusion in boot process (people sometimes thought it meant the collar was ready)