### PR TITLE
Update oc_cuff_themes per Issue #892

### DIFF
--- a/src/cuffs/oc_cuff_themes.lsl
+++ b/src/cuffs/oc_cuff_themes.lsl
@@ -269,7 +269,7 @@ default
         if(iNum == -1){ // oc_cuff sends this when it starts (which is also on_rez)
             llResetScript();
         }
-        if (iNum == 32) // [New Theme] from oc_cuff script
+        if (iNum == 33) // [New Theme] from oc_cuff script
         {
             PrintCurrentProperties(kID);
         }


### PR DESCRIPTION
It looks like there was a single number incorrect in the oc_cuff_themes script. The oc_cuff script was sending iNum == 33, and the oc_cuff_themes script was looking for iNum == 32