### PR TITLE
fix some wrongs in DIALOG, DIALOG_RESPONSE & DIALOG_TIMEOUT

### DIFF
--- a/src/Apps/oc_OwnerOnlineCheck.lsl
+++ b/src/Apps/oc_OwnerOnlineCheck.lsl
@@ -6,7 +6,7 @@ Copyright ©2021
 
 Aria (Tashia Redrose)
     *Jan 2021       -       Created optional app for notification on owner login
-    
+
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -68,7 +68,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -87,7 +87,7 @@ UserCommand(integer iNum, string sStr, key kID) {
     if (llToLower(sStr)==llToLower(g_sSubMenu) || llToLower(sStr) == "menu "+llToLower(g_sSubMenu)) Menu(kID, iNum);
     //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else {
-        //integer iWSuccess = 0; 
+        //integer iWSuccess = 0;
         //string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
         //string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         //string sText;
@@ -97,7 +97,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 integer g_iLocked=FALSE;
 integer g_iInterval=60;
 integer g_iEnable;
@@ -146,7 +145,7 @@ UpdateOwner(key ID, integer online)
     if(index==-1) g_lOwners += [ID, online];
     else {
         integer lastState = (integer)llList2String(g_lOwners,index+1);
-        
+
         //llSay(0, "UPDATE called ("+(string)lastState+", "+(string)lastRegion+") [secondlife:///app/agent/"+(string)ID+"/about] = ("+(string)online+", "+(string)inRegion+")");
         if(lastState==online){}
         else {
@@ -195,7 +194,7 @@ state active
         g_kWearer = llGetOwner();
         llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "global_locked","");
     }
-    
+
     timer(){
         if(g_iEnable){
             llSetTimerEvent(g_iInterval);
@@ -205,7 +204,7 @@ state active
             return;
         }
     }
-    
+
     dataserver(key kID, string sData)
     {
         if(HasDSRequest(kID)!=-1){
@@ -224,7 +223,7 @@ state active
             }
         }
     }
-    
+
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) UserCommand(iNum, sStr, kID);
         else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
@@ -233,7 +232,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -258,9 +257,9 @@ state active
                         g_iTypeDialog=1-g_iTypeDialog;
                         llMessageLinked(LINK_SET, LM_SETTING_SAVE, "ownerchecks_typedialog="+(string)g_iTypeDialog,"");
                     }
-                    
+
                     if(iRespring)Menu(kAv,iAuth);
-                        
+
                 } else if(sMenu == "Menu~Interval"){
                     g_iInterval=(integer)sMsg;
                     llSetTimerEvent(g_iEnable);
@@ -270,14 +269,14 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);
             string sToken = llList2String(lSettings,0);
             string sVar = llList2String(lSettings,1);
             string sVal = llList2String(lSettings,2);
-            
+
             if(sToken=="auth"){
                 if(sVar=="owner"){
                     g_lOwners=[];
@@ -300,8 +299,8 @@ state active
                 }else if(sVar == "typedialog"){
                     g_iTypeDialog=(integer)sVal;
                 }
-            } 
-            
+            }
+
             if(sStr == "settings=sent")
             {
                 llSetTimerEvent(g_iEnable);

--- a/src/Apps/oc_badwords.lsl
+++ b/src/Apps/oc_badwords.lsl
@@ -1,8 +1,8 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2008 - 2016 Lulu Pink, Nandana Singh, Garvin Twine,    
-// Cleo Collins, Satomi Ahn, Joy Stipe, Wendy Starfall, Romka Swallowtail, 
-// littlemousy, Karo Weirsider, Nori Ovis, Ray Zopf et al.         
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2008 - 2016 Lulu Pink, Nandana Singh, Garvin Twine,
+// Cleo Collins, Satomi Ahn, Joy Stipe, Wendy Starfall, Romka Swallowtail,
+// littlemousy, Karo Weirsider, Nori Ovis, Ray Zopf et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 
 string g_sAppVersion = "¹⋅³";
@@ -54,7 +54,6 @@ integer g_iListenerHandle;
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride=3;
 integer g_iIsEnabled=0;
 
 integer g_iHasSworn = FALSE;
@@ -81,7 +80,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_THIS, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
     //Debug("Made "+sName+" menu.");
 }
@@ -373,7 +372,7 @@ default {
                 string sMessage = llList2String(lMenuParams, 1);
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
                 string sMenu=llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if (sMenu=="BadwordsMenu") {
                     if (sMessage == "BACK") llMessageLinked(LINK_ROOT, iAuth, "menu apps", kAv);
                     else UserCommand(iAuth, "badwords "+sMessage, kAv, TRUE);
@@ -405,7 +404,7 @@ default {
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
     }
 

--- a/src/Apps/oc_cagehome.lsl
+++ b/src/Apps/oc_cagehome.lsl
@@ -1,7 +1,7 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2008 - 2016 Satomi Ahn, Nandana Singh, Joy Stipe,     
-// Wendy Starfall, Sumi Perl, littlemousy, Romka Swallowtail et al.    
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2008 - 2016 Satomi Ahn, Nandana Singh, Joy Stipe,
+// Wendy Starfall, Sumi Perl, littlemousy, Romka Swallowtail et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 
 // Based on original version and idea by Kaly Shinn & Tuco Solo
@@ -237,7 +237,6 @@ integer g_iRlvActive = TRUE; // we'll get updates from the rlv script(s)
 
 // handles
 list    g_lMenuIDs;
-integer g_iMenuStride = 3;
 
 key     g_kSimPosRequestHandle; // UUID of the dataserver request
 key     g_kOwnerRequestHandle;
@@ -262,7 +261,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtility, integer iPage, int
     llMessageLinked(LINK_THIS, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" +
     llDumpList2String(lChoices,"`") + "|" + llDumpList2String(lUtility,"`")+"|"+(string)iAuth,kMenuID);
     integer i = llListFindList(g_lMenuIDs, [kID]);
-    if (~i) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], i, i + g_iMenuStride - 1);
+    if (~i) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], i, i + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -629,7 +628,7 @@ UserCommand(integer iAuth, string sStr, key kID) {
     if (sStr=="menu "+g_sSubMenu || sStr==g_sSubMenu || sStr==g_sChatCmd) MenuMain(kID,iAuth);
     else if (llToLower(sStr) == "rm cagehome") {
         if (kID!=g_kWearer && iAuth!=CMD_OWNER) llMessageLinked(LINK_THIS,NOTIFY,"0"+"%NOACCESS%",kID);
-        else Dialog(kID, "\nDo you really want to uninstall the "+g_sSubMenu+" App?", ["Yes","No","Cancel"], [], 0, iAuth,"rmcagehome");        
+        else Dialog(kID, "\nDo you really want to uninstall the "+g_sSubMenu+" App?", ["Yes","No","Cancel"], [], 0, iAuth,"rmcagehome");
     } else if (sStr == "settings") { // collar's command to request settings of all modules
         string sMsg = g_sPluginTitle+": "+llList2String(lSTATES, g_iState);
         if (g_sCageRegion!="") sMsg += ", TP Location: "+Map(g_sCageRegion, g_vCagePos);
@@ -779,7 +778,7 @@ default {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if (iMenuIndex == -1) return;
             string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
             // got a menu response meant for us, extract the sValues
             list lMenuParams = llParseString2List(sStr, ["|"], []);
             key kAv = (key)llList2String(lMenuParams, 0);
@@ -823,10 +822,10 @@ default {
                     llMessageLinked(LINK_THIS, NOTIFY, "1"+g_sSubMenu+" App has been removed.", kAv);
                 if (llGetInventoryType(llGetScriptName()) == INVENTORY_SCRIPT) llRemoveInventory(llGetScriptName());
                 } else llMessageLinked(LINK_THIS, NOTIFY, "0"+g_sSubMenu+" App remains installed.", kAv);
-            }         
+            }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
     }
 

--- a/src/Apps/oc_camera.lsl
+++ b/src/Apps/oc_camera.lsl
@@ -1,7 +1,7 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2011 - 2016 Nandana Singh, Wendy Starfall, Medea Destiny, 
-// littlemousy, Romka Swallowtail, Garvin Twine et al.           
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2011 - 2016 Nandana Singh, Wendy Starfall, Medea Destiny,
+// littlemousy, Romka Swallowtail, Garvin Twine et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 
 //allows owner to set different camera mode
@@ -56,7 +56,6 @@ integer DIALOG_RESPONSE = -9001;
 integer DIALOG_TIMEOUT = -9002;
 
 list g_lMenuIDs;  //menu information
-integer g_iMenuStride=3;
 
 string UPMENU = "BACK";
 
@@ -127,7 +126,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_THIS, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -388,7 +387,7 @@ default {
                 // integer iPage = (integer)llList2String(lMenuParams, 2);
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if (sMenuType == "camera") {
                     if (sMessage == UPMENU)
                         llMessageLinked(LINK_ROOT, iAuth, "menu " + g_sParentMenu, kAv);
@@ -406,7 +405,7 @@ default {
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
     }
 

--- a/src/Apps/oc_capture.lsl
+++ b/src/Apps/oc_capture.lsl
@@ -103,7 +103,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -250,7 +250,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -354,13 +353,13 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         }
         else if(iNum == DIALOG_RESPONSE){
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);

--- a/src/Apps/oc_customizer.lsl
+++ b/src/Apps/oc_customizer.lsl
@@ -1,6 +1,6 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2014 - 2016 Romka Swallowtail et al.           
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2014 - 2016 Romka Swallowtail et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 
 
@@ -43,7 +43,6 @@ string g_sCurrentElement ;
 list g_lCurrentParam ;
 
 list g_lMenuIDs;//3-strided list of kAv, dialogid, menuname
-integer g_iMenuStride = 3;
 
 
 /*
@@ -69,7 +68,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     integer iMenuIndex = llListFindList(g_lMenuIDs, [kRCPT]);
     list lAddMe = [kRCPT, kMenuID, sMenuType];
     if (iMenuIndex == -1) g_lMenuIDs += lAddMe;
-    else g_lMenuIDs = llListReplaceList(g_lMenuIDs, lAddMe, iMenuIndex, iMenuIndex + g_iMenuStride - 1);
+    else g_lMenuIDs = llListReplaceList(g_lMenuIDs, lAddMe, iMenuIndex, iMenuIndex + 2);
 }
 
 ElementMenu(key kAv, integer iPage, integer iAuth)
@@ -229,7 +228,7 @@ default
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
 
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
 
                 if (sMenuType == "ElementMenu")
                 {
@@ -302,7 +301,7 @@ default
         else if (iNum == DIALOG_TIMEOUT)
         {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if (iMenuIndex != -1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
         }
     }
 

--- a/src/Apps/oc_detach.lsl
+++ b/src/Apps/oc_detach.lsl
@@ -1,4 +1,4 @@
-  
+
 /*
 This file is a part of OpenCollar.
 Copyright ©2021
@@ -7,8 +7,8 @@ Copyright ©2021
 
 Aria (Tashia Redrose)
     * Dec 2019      - Rewrote Outfits & Reset Script Version to 1.0
-    
-    
+
+
 et al.
 
 Licensed under the GPLv2. See LICENSE for full details.
@@ -71,7 +71,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth + "|1", kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -79,27 +79,26 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
 
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[Detach App]";
-    
+
     Dialog(kID, sPrompt, llGetAttachedList(llGetOwner()),  [UPMENU], 0, iAuth, "Menu~Main");
 }
 
 UserCommand(integer iNum, string sStr, key kID) {
     if (llSubStringIndex(sStr,llToLower(g_sSubMenu)) && sStr != "menu "+g_sSubMenu) return;
-    
+
     if (sStr==g_sSubMenu || sStr == "menu "+g_sSubMenu) Menu(kID, iNum);
     //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else {
-        integer iWSuccess = 0; 
+        integer iWSuccess = 0;
         string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
         string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         string sText;
-        
+
     }
 }
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 integer g_iLocked=FALSE;
 integer ALIVE = -55;
 integer READY = -56;
@@ -140,7 +139,7 @@ state active
 /*    timer(){
         llSetText("Free Memory (oc_detach)\n"+(string)llGetFreeMemory()+"\n \n \n \n \n \n \n \n \n \n \n \n", <0,1,1>,1);
     }
-*/    
+*/
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) UserCommand(iNum, sStr, kID);
         else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
@@ -149,12 +148,12 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
-                
+
                 if(sMenu == "Menu~Main"){
                     if(sMsg == UPMENU) llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     else{
@@ -166,7 +165,7 @@ state active
             }
         }else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == REBOOT)llResetScript();
         //llOwnerSay(llDumpList2String([iSender,iNum,sStr,kID],"^"));
     }

--- a/src/Apps/oc_outfits.lsl
+++ b/src/Apps/oc_outfits.lsl
@@ -93,7 +93,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -272,7 +272,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -388,7 +387,7 @@ state active
 
         }else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         }
         else if(iNum == DIALOG_RESPONSE){
 
@@ -404,7 +403,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 //list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);

--- a/src/Apps/oc_presets.lsl
+++ b/src/Apps/oc_presets.lsl
@@ -47,7 +47,6 @@ integer DIALOG_TIMEOUT = -9002;
 key g_kWearer;
 
 list g_lMenuIDs;
-integer g_iMenuStride = 3;
 
 list g_lPresets;  // [sName, "vScale/vPos/vRot"]
 
@@ -55,7 +54,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     key kMenuID = llGenerateKey();
     llMessageLinked(LINK_THIS, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, sMenuType];
 }
 
@@ -207,7 +206,7 @@ state active
                 //integer iPage = (integer)llList2String(lMenuParams, 2);
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if (sMenuType == g_sSubMenu) {
                     if (sMessage == UPMENU) llMessageLinked(LINK_ROOT, iAuth, "menu " + g_sParentMenu, kAv);
                     else PresetMenu(kAv, iAuth, sMessage);
@@ -238,16 +237,16 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
         else if(iNum == LINK_CMD_DEBUG){
-            
+
             integer onlyver=0;
             if(sStr == "ver")onlyver=1;
             llInstantMessage(kID, llGetScriptName() +" SCRIPT VERSION: "+g_sScriptVersion);
             if(onlyver)return; // basically this command was: <prefix> versions
             llInstantMessage(kID, llGetScriptName() + " PRESETS: "+llDumpList2String(llList2ListStrided(g_lPresets, 0, -1, 2), " | "));
         }
-            
+
     }
  }

--- a/src/Apps/oc_shocker.lsl
+++ b/src/Apps/oc_shocker.lsl
@@ -60,7 +60,6 @@ string g_sShockSound;
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride=3;
 
 integer g_iShock = FALSE ;
 integer g_iDefaultAnim = FALSE;
@@ -72,7 +71,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_THIS, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -250,7 +249,7 @@ default {
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
                 //remove stride from g_lMenuIDs
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
 
                 if (sMenu == "shocker") {
                     if (sMsg == UPMENU) llMessageLinked(LINK_THIS, iAuth, "menu "+g_sParentMenu, kAv);
@@ -280,7 +279,7 @@ default {
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
     }
 

--- a/src/Apps/oc_spy.lsl
+++ b/src/Apps/oc_spy.lsl
@@ -59,8 +59,8 @@ string g_sSubMenu = "Spy";
 
 string g_scmd_menu = "\nTrace: Location trace\nSub Chat: Monitor Sub's speech\nAtt Chat: Monitor Sub's Attachments\nRadar: Report Nearby Avatars\n\nUse Attachment Chat monitoring with caution as attachments can be noisy.";
 //list g_lcmds = ["trace", "sub chat", "att chat", "radar"];
-list g_lSensRates = ["240","120","90","60","30"];    
-list g_lSensDist = ["20","15","10","5"];    
+list g_lSensRates = ["240","120","90","60","30"];
+list g_lSensDist = ["20","15","10","5"];
 
 
 // Globals for App
@@ -84,7 +84,6 @@ integer g_announce;
 key g_kWearer;
 //string g_sWearerName;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner=[];
 integer g_iLocked=FALSE;
 
@@ -184,14 +183,14 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" +     llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[Spy App]\nVersion: " + g_sAppVersion + "\n" + g_scmd_menu + "\n\nCurrent Sensor Rate: " + (string)g_iSensorRepeat + "\nCurrent Sensor Distance: " + (string)g_iSensorRange;
     list lButtons = ["Rate...","Range...", Checkbox(g_itrace, "Trace"), Checkbox(g_iradar, "Radar"), Checkbox(g_isubchat, "SubChat"), Checkbox(g_iattchat, "AttChat")];
-    
+
     Dialog(kID, sPrompt, lButtons, [UPMENU], 0, iAuth, "Menu~Spy");
 }
 
@@ -248,7 +247,7 @@ UserCommand(integer iNum, string sStr, key kID) {
         string sChangetype = llToLower(llList2String(llParseString2List(sStr, [" "], []),0));
         string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         //string sText;
-        // handle chat commands 
+        // handle chat commands
         list lChatCmds = ["spychat", "spyattach", "spyradar", "spytrace", "spyrange", "spyrate"];
         integer iVal=FALSE;
         if (llToLower(sChangevalue) == "on")
@@ -270,12 +269,12 @@ UserCommand(integer iNum, string sStr, key kID) {
                 string sVal = "off";
                 if (iVal) sVal = "on";
                 Notify(kID, "Spy Avatar Radar turned "+sVal);
-            } else if (iCmdIndex==3) { // Location 
+            } else if (iCmdIndex==3) { // Location
                 g_itrace = iVal;
                 string sVal = "off";
                 if (iVal) sVal = "on";
                 Notify(kID, "Spy Trace Location turned "+sVal);
-            } else if (iCmdIndex==4) { // Range 
+            } else if (iCmdIndex==4) { // Range
                 iVal = (integer)sChangevalue;
                 if (iVal<5 || iVal>20)  {
                     Notify(kID, "Error, range must be between 5 and 20");
@@ -283,7 +282,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                 }
                 g_iSensorRange = iVal;
                 Notify(kID, "Spy Radar Range set to "+(string)iVal+" meters");
-            } else if (iCmdIndex==5) { // Rate 
+            } else if (iCmdIndex==5) { // Rate
                 iVal = (integer)sChangevalue;
                 if (iVal<60 || iVal>300)  {
                     Notify(kID, "Error, rate must be between 60 and 300");
@@ -294,7 +293,7 @@ UserCommand(integer iNum, string sStr, key kID) {
             }
             SaveSettings();    // Save just in case they changed anything.
         }
-        
+
     }
 }
 
@@ -305,7 +304,7 @@ AddLog(string msg) {
     if (llStringLength(g_sreport) > 500)
         SendLog();    // If half full, send early
 
-    llSetTimerEvent(20);                        
+    llSetTimerEvent(20);
 }
 
 SendLog() {
@@ -355,7 +354,7 @@ UpdateSensor() {
         }
         g_announce = TRUE;
         llSensorRepeat("" ,"" , AGENT, g_iSensorRange, PI, g_iSensorRepeat);
-    
+
         if (g_iattchat)
             g_iListenerHandle = llListen(0, "", NULL_KEY , "");    // Listen to everything
         else if (g_isubchat)
@@ -380,7 +379,7 @@ default
         llSetTimerEvent(0);
         SendLog();
     }
-    
+
     state_entry() {
         g_kWearer = llGetOwner();
         llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "global_locked","");
@@ -436,7 +435,7 @@ default
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -444,13 +443,13 @@ default
                 integer iRespring=TRUE;
                 if(sMenu == "Menu~Spy"){
                     if(sMsg == UPMENU) {
-                        iRespring=FALSE;                
+                        iRespring=FALSE;
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     } else if (sMsg == "Rate...") {
                         MenuSensorRate(kAv,iAuth);
                         return;
                     } else if (sMsg == "Range...") {
-                        MenuSensorDist(kAv,iAuth);    
+                        MenuSensorDist(kAv,iAuth);
                         return;
                     } else { // menu button is an option toggle
                         if(iAuth != CMD_OWNER || kAv == g_kWearer){
@@ -459,7 +458,7 @@ default
                             return;
                         }
                     }
-                    
+
                     if(sMsg == Checkbox(g_itrace, "Trace")){
                         g_itrace=1-g_itrace;
                     } else if(sMsg == Checkbox(g_iradar, "Radar")){
@@ -471,7 +470,7 @@ default
                     }
 
                     SaveSettings();
-                    if(iRespring){                                  
+                    if(iRespring){
                         Menu(kAv,iAuth);
                     }
                     UpdateSensor();
@@ -504,10 +503,10 @@ default
                     Menu(kAv,iAuth);
                 }
             }
-            
+
         }else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE) {
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);
@@ -528,8 +527,8 @@ default
                     g_itrace=llList2Integer(lSettings,2);
                 else if(llList2String(lSettings,1)=="range")
                     g_iSensorRange=llList2Integer(lSettings,2);
-                else if(llList2String(lSettings,1)=="rate") 
-                    g_iSensorRepeat=llList2Integer(lSettings,2);                    
+                else if(llList2String(lSettings,1)=="rate")
+                    g_iSensorRepeat=llList2Integer(lSettings,2);
                 UpdateSensor();
             } else if(llList2String(lSettings,0)=="auth"){
                 if(llList2String(lSettings,1)=="owner") {

--- a/src/Apps/oc_timer.lsl
+++ b/src/Apps/oc_timer.lsl
@@ -1,8 +1,8 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2008 - 2017 Satomi Ahn, Nandana Singh, Joy Stipe,     
-// Wendy Starfall, Master Starship, Medea Destiny, littlemousy,      
-// Romka Swallowtail, Sumi Perl, Keiyra Aeon, Garvin Twine et al.     
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2008 - 2017 Satomi Ahn, Nandana Singh, Joy Stipe,
+// Wendy Starfall, Master Starship, Medea Destiny, littlemousy,
+// Romka Swallowtail, Sumi Perl, Keiyra Aeon, Garvin Twine et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 string g_sAppVersion = "¹⋅⁴";
 
@@ -93,7 +93,6 @@ list g_lLocalMenu;
 key g_kWearer;
 // handles
 list g_lMenuIDs;
-integer g_iMenuStride = 3;
 
 
 /*
@@ -115,7 +114,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtility, integer iPage, int
     llMessageLinked(LINK_THIS, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtility, "`") + "|" + (string)iAuth, kMenuID);
 
     integer i = llListFindList(g_lMenuIDs, [kID]);
-    if (~i) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], i, i + g_iMenuStride - 1);
+    if (~i) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], i, i + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -482,7 +481,7 @@ default {
             if (iMenuIndex == -1) return;
             //this is one of our menus
             string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
             list lMenuParams = llParseString2List(sStr, ["|"], []);
             key kAv = (key)llList2String(lMenuParams, 0);
             string sMsg = llList2String(lMenuParams, 1);
@@ -509,7 +508,7 @@ default {
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
     }
 

--- a/src/Apps/oc_undress.lsl
+++ b/src/Apps/oc_undress.lsl
@@ -8,18 +8,18 @@ Aria (Tashia Redrose)
 Medea (Medea Destiny)
     * Jun 2021      -       Quick despam: stores mask values as they are set in g_lLastMask to only release restrictions
                             that have actually been set.
-    * Jul 2021      -       * issue #528: Handling layers: As of RLVa 2.3.0: Tattoos, alphas and universal layers show up 
-                            in getoutfit unless the layer is locked and the Hide Locked Layers setting is on. They can 
+    * Jul 2021      -       * issue #528: Handling layers: As of RLVa 2.3.0: Tattoos, alphas and universal layers show up
+                            in getoutfit unless the layer is locked and the Hide Locked Layers setting is on. They can
                             be locked or removed. The physics layer layer can be locked, but cannot be removed and does
                             not show up in getoutfit. I'm not certain of the current status of Marine's RLV, but I last
-                            I knew neither physics nor universal layers can be accessed. We need to extend the 
+                            I knew neither physics nor universal layers can be accessed. We need to extend the
                             functionality to cover the extra layers, but this is problematic. This fix ignores the physics
-                            layer in locks due to current broken-ness, warns about locked layers not showing up, and will 
-                            not require refactoring for updates that increase the number of layers handled. 
+                            layer in locks due to current broken-ness, warns about locked layers not showing up, and will
+                            not require refactoring for updates that increase the number of layers handled.
                             * Added chat handling: (prefix)undress (layer) removes layers. (prefix)undress lock (layer)
                             and (prefix)undress unlock (layer) set layer locks. Some rejigging of usercommand filtering
                             to handle this cleanly.
-                            * Added short llSleep before remenuing after detaching a clothing layer to ensure the viewer 
+                            * Added short llSleep before remenuing after detaching a clothing layer to ensure the viewer
                             removes the layer before replying to the getoutfit command.
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
@@ -73,7 +73,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -117,14 +117,13 @@ UserCommand(integer iNum, string sStr, key kID) {
                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, "undress_mask="+llDumpList2String(g_lMasks,"|"),"");
             }
         }else if(llListFindList(g_lLayers,[sCmd])!=-1){
-            if(llListFindList(["skin","hair","eyes","shape","physics"],[sCmd])==-1) llOwnerSay("@remoutfit:"+sCmd+"=force"); 
-            }      
+            if(llListFindList(["skin","hair","eyes","shape","physics"],[sCmd])==-1) llOwnerSay("@remoutfit:"+sCmd+"=force");
+            }
     }
 }
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 //list g_lOwner;
 //list g_lTrust;
 //list g_lBlock;
@@ -163,7 +162,7 @@ ApplyMask(){
 CLock(key kAv, integer iAuth){
     string sPrompt = "[Undress - Clothing Locks]\n\nThis menu will allow you to lock or unlock clothing layers.\nNote that Physics and Universal layer locking may not work on a viewer using RLV rather than RLVa.";
     list lButtons = [];
-    
+
     // Create checkboxes
     integer i = 0;
     integer end = llGetListLength(g_lLayers);
@@ -174,7 +173,7 @@ CLock(key kAv, integer iAuth){
         else
             lButtons += Checkbox(FALSE,llList2String(g_lLayers,i));
     }
-    
+
     Dialog(kAv, sPrompt, lButtons, [UPMENU], 0, iAuth, "undress~locks");
 }
 
@@ -237,7 +236,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -261,7 +260,7 @@ state active
                         CLock(kAv,iAuth);
                         iRespring=FALSE;
                     }
-                    
+
                     if(iRespring)
                         Menu(kAv,iAuth);
                 } else if(sMenu == "undress~select"){
@@ -271,7 +270,7 @@ state active
                     } else {
                         llOwnerSay("@remoutfit:"+sMsg+"=force");
                     }
-                    
+
                     if(iRespring){
                         llSleep(1); //Give the viewer a moment to remove layer before remenuing.
                         g_iOutfitScan = llRound(llFrand(58439875));
@@ -293,28 +292,28 @@ state active
                         }else {
                             if(index==-1)g_lMasks+=llList2String(lLabel,1);
                         }
-                        
+
                         llMessageLinked(LINK_SET, LM_SETTING_SAVE, "undress_mask="+llDumpList2String(g_lMasks,"|"),"");
                     }
-                    
-                    
+
+
                     if(iRespring)CLock(kAv,iAuth);
                 }
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);
             string sToken = llList2String(lSettings,0);
             string sVar = llList2String(lSettings,1);
             string sVal = llList2String(lSettings,2);
-            
-            
+
+
             //integer ind = llListFindList(g_lSettingsReqs, [sToken+"_"+sVar]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             if(sToken=="global"){
                 if(sVar=="locked"){
                     g_iLocked=(integer)sVal;
@@ -330,7 +329,7 @@ state active
         } else if(iNum == LM_SETTING_EMPTY){
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             if(sStr == "undress_mask"){
                 g_lMasks = [];
                 ApplyMask();
@@ -340,19 +339,19 @@ state active
             // This is recieved back from settings when a setting is deleted
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             list lSettings = llParseString2List(sStr, ["_"],[]);
             if(llList2String(lSettings,0)=="global")
                 if(llList2String(lSettings,1) == "locked") g_iLocked=FALSE;
         }
         //llOwnerSay(llDumpList2String([iSender,iNum,sStr,kID],"^"));
     }
-    
-    
+
+
     listen(integer c,string n,key i,string m){
         if(c == g_iOutfitScan){
             llListenRemove(g_iOutfitLstn);
-            
+
             list lButtons;
             integer iEnd = llStringLength(m)-1;
             integer i=-1;

--- a/src/collar/oc_addons.lsl
+++ b/src/collar/oc_addons.lsl
@@ -4,20 +4,20 @@ Copyright ©2021
 : Contributors :
 Aria (Tashia Redrose)
     *January 2021       -       Created oc_addons
-    
+
 Medea (medea.destiny)
     Sept 2021           -   Provided auth failure mode for menu. Insufficient auth now
-                            provides suitable notification to user and respawns main menu. 
-                            Fixes issue #665   
+                            provides suitable notification to user and respawns main menu.
+                            Fixes issue #665
 
 KristenMynx
     Dec 2021            -   Fix timeout removal stride
     May 2022            -   Fix offline removal stride
                         -   Reduce chatter
     Jun 2022            -   Reduce chatter more
-    
-    
-    
+
+
+
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -161,7 +161,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -185,7 +185,7 @@ UserCommand(integer iNum, string sStr, key kID) {
             llMessageLinked(LINK_SET,0,"menu",kID);
         }
         else AddonsMenu(kID, iNum);
-    }    
+    }
     //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else {
         if (iNum<CMD_OWNER || iNum>CMD_WEARER) return;
@@ -229,7 +229,6 @@ key g_kAddonPending;
 string g_sAddonName;
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride = 3;
 integer g_iLocked=FALSE;
 
 integer ALIVE = -55;
@@ -451,7 +450,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -479,7 +478,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(iMenuIndex!=-1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);

--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -9,7 +9,7 @@ Aria (Tashia Redrose)
     Dec 2020  - Fix bug where animations were not treated case insensitive, and where animations
                      with a space in the name could not be played by chat command or menu button
     Feb 2021  - Fix Public Access
-    
+
 Felkami (Caraway Ohmai)
     Dec 2020  - Fixed #456, #462, #461, added LockMeister AO suppress
 
@@ -94,7 +94,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -119,7 +119,7 @@ integer g_iPosture = FALSE;
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[Animations]\n\nCurrent Animation: "+setor((g_lCurrentAnimations==[]), "None", llList2String(g_lCurrentAnimations, 0)+"\nCurrent Pose: "+setor((g_sPose==""), "None", g_sPose));
     list lButtons = [Checkbox(g_iAnimLock,"AnimLock"), "Pose"];
-    
+
     if(llGetInventoryType("~stiff")==INVENTORY_ANIMATION){
         lButtons += [Checkbox(g_iPosture, "Posture")];
     }else {
@@ -147,19 +147,19 @@ list GetPoseList(integer iType)
 {
     // -1 = as it exists in inventory
     // 0 = lower case
-    
+
     list lTmp;
     integer i=0;
     integer end = llGetInventoryNumber(INVENTORY_ANIMATION);
     for(i=0;i<end;i++){
-        
+
         string name = llGetInventoryName(INVENTORY_ANIMATION, i);
         if(llGetSubString(name,0,0)!="~"){
             if(iType == -1)lTmp += [name];
             else lTmp += [llToLower(name)];
         }
     }
-    
+
     return lTmp;
 }
 
@@ -173,19 +173,19 @@ UserCommand(integer iNum, string sStr, key kID) {
     //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else {
         list lTmp = llParseString2List(sStr, [" "],[]);
-        //integer iWSuccess = 0; 
+        //integer iWSuccess = 0;
         string sChangetype = llList2String(lTmp,0);
         string sChangevalue = llList2String(lTmp,1);
         integer iPageNum = llList2Integer(lTmp,2);
         integer iRespringPoses=FALSE;
-        
+
         if(llSubStringIndex(sStr,"remenu") != -1){
             integer len = llGetListLength(lTmp);
             len = len-3;
             sChangetype = llDumpList2String(llList2List(lTmp, 0,len), " ");
             sChangevalue = llList2String(lTmp, len+1);
             iPageNum = llList2Integer(lTmp, len+2);
-            
+
             //llSay(0, "anim remenu: "+sStr+";;;; "+sChangetype+";"+sChangevalue+";"+(string)iPageNum);
         }
         //string sText;
@@ -236,24 +236,24 @@ UserCommand(integer iNum, string sStr, key kID) {
                     if(iPos==-1){
                        // llOwnerSay("up:"+(string)iUp+"; anim not found in adjustments");
                         // OK now we make a new entry
-                        
+
                         if(iUp)
                             g_lAdjustments+=[llList2String(g_lCurrentAnimations, 0), g_fAdjustment];
                         else
                             g_lAdjustments+=[llList2String(g_lCurrentAnimations, 0),-g_fAdjustment];
-                            
-                        
+
+
                         llMessageLinked(LINK_SET, NOTIFY, "0The hover height for '"+llList2String(g_lCurrentAnimations, 0)+"' is now "+(string)g_fAdjustment, g_kWearer);
                     } else {
-                        
+
                         //llOwnerSay("up:"+(string)iUp+"; anim update");
                         float fCurrent = (float)llList2String(g_lAdjustments, iPos+1);
                         if(iUp)
                             fCurrent+=g_fAdjustment;
                         else
                             fCurrent -= g_fAdjustment;
-                        
-                        
+
+
                         llMessageLinked(LINK_SET, NOTIFY, "0The hover height for '"+llList2String(g_lCurrentAnimations, 0)+"' is now "+(string)fCurrent, g_kWearer);
                         if(fCurrent!=0)
                             g_lAdjustments = llListReplaceList(g_lAdjustments, [fCurrent],iPos+1,iPos+1);
@@ -261,12 +261,12 @@ UserCommand(integer iNum, string sStr, key kID) {
                             g_lAdjustments = llDeleteSubList(g_lAdjustments,iPos,iPos+1);
                     }
                     llMessageLinked(LINK_SET, LM_SETTING_SAVE, "offset_hovers="+llDumpList2String(g_lAdjustments,","),"");
-                    
+
                     //llOwnerSay("up:"+(string)iUp+"; saved hover list");
                     if(llGetListLength(g_lCurrentAnimations)!=0)
                         PlayAnimation();
-                    
-                    
+
+
                 }
             }else llMessageLinked(LINK_SET, NOTIFY, "%NOACCESS% to changing height", kID);
         } else if(sChangetype == "animlock"){
@@ -280,7 +280,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                     llMessageLinked(LINK_SET, LM_SETTING_DELETE, "anim_animlock","");
                 text = "0Animation lock updated";
             } else text = "0%NOACCESS% to change animation lock";
-            
+
             if(sChangevalue == "remenu") Menu(kID,iNum);
             else llMessageLinked(LINK_SET, NOTIFY, text, kID);
         } else if(llToLower(sChangetype) == "pose"){
@@ -296,9 +296,9 @@ UserCommand(integer iNum, string sStr, key kID) {
                     llMessageLinked(LINK_SET, LM_SETTING_SAVE, "anim_posture=1", "");
                 }
             } else llMessageLinked(LINK_SET,NOTIFY,"0%NOACCESS% to toggling posture", kID);
-            
+
         }
-        
+
         @checkRemenu;
         if(sChangevalue == "remenu" && iRespringPoses)PoseMenu(kID,iNum, iPageNum);
         //else if(sChangevalue == "remenu" && !iRespringPoses)Menu(kID, iNum);
@@ -309,7 +309,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 integer g_iPermissionGranted=FALSE;
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -464,11 +463,11 @@ state active
 
         llRequestPermissions(g_kWearer, PERMISSION_OVERRIDE_ANIMATIONS | PERMISSION_TRIGGER_ANIMATION | PERMISSION_TAKE_CONTROLS);
     }
-    
+
     changed(integer t){
         if(t&CHANGED_INVENTORY)llResetScript(); // maybe changed animations
     }
-    
+
     run_time_permissions(integer iPerms){
         // Check if both permissions granted
         if(iPerms& PERMISSION_OVERRIDE_ANIMATIONS && iPerms&PERMISSION_TRIGGER_ANIMATION && iPerms&PERMISSION_TAKE_CONTROLS){
@@ -487,7 +486,7 @@ state active
                 TRUE,TRUE);
         }
     }
-    
+
     timer(){
         if(g_iLeashMove)return;
         string sAnim = llGetAnimation(g_kWearer);
@@ -496,13 +495,13 @@ state active
             llSetTimerEvent(FALSE);
             return;
         }
-        
+
         if(sAnim == "Falling Down" || sAnim == "Jumping" || sAnim == "Landing" || sAnim == "Soft Landing"){
             llResetTime();
         }
-        
+
         if(llGetTime()>30.0)llSetTimerEvent(FALSE);
-        
+
         if(g_iTimerMode == TIMER_START_ANIMATION && llGetTime()>2.5){
             if(g_lCurrentAnimations==[]){
                 if(g_fStandHover != 0) llMessageLinked(LINK_SET, RLV_CMD, "adjustheight:1;0;"+(string)g_fStandHover,g_kWearer);
@@ -510,7 +509,7 @@ state active
             llSetTimerEvent(FALSE);
         }
     }
-    
+
     control(key kID, integer iLevel, integer iEdge){
         if(iLevel == 0){
             // all movement has ceased
@@ -518,15 +517,15 @@ state active
         } else {
             MoveStart();
         }
-                
+
         //integer iStart = iLevel & iEdge;
         //integer iEnd = ~iLevel & iEdge;
         //integer iHeld = iLevel & ~iEdge;
         //integer iUntouched = ~(iLevel | iEdge);
-        
+
         //llWhisper(0, "controls: "+llDumpList2String([iLevel, iEdge, iStart, iEnd, iHeld, iUntouched], ", "));
     }
-    
+
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) UserCommand(iNum, sStr, kID);
         else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu){
@@ -545,19 +544,19 @@ state active
             }
         }
         else if(iNum == DIALOG_RESPONSE){
-        
+
 
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iPage = llList2Integer(lMenuParams,2);
                 integer iAuth = llList2Integer(lMenuParams,3);
                 integer iRespring = TRUE;
-                
+
                 if(sMenu == "Menu~Animations"){
                     if(sMsg == UPMENU) {
                         iRespring=FALSE;
@@ -581,7 +580,7 @@ state active
                                 llMessageLinked(LINK_SET, 0, "posture on",kAv);
                             }
                         }
-                        
+
                     }else {
                         iRespring=FALSE;
                         llMessageLinked(LINK_SET, iAuth, "menu "+sMsg,kAv);
@@ -592,7 +591,7 @@ state active
                     if(sMsg == UPMENU){
                         iRespring=FALSE;
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sSubMenu, kAv);
-                    
+
                     } else {
                         // Set standing animation
                         llMessageLinked(LINK_SET, 0, sMsg + " remenu "+(string)iPage, kAv);
@@ -603,20 +602,20 @@ state active
                     if(iRespring)PoseMenu(kAv,iAuth, iPage);
                 }
             }
-            
+
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(iMenuIndex!=-1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);
             string sTok = llList2String(lSettings,0);
             string sVar = llList2String(lSettings,1);
             string sVal = llList2String(lSettings,2);
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sTok + "_" + sVar]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             if(sTok=="global"){
                 if(sVar=="locked"){
                     g_iLocked=(integer)sVal;
@@ -648,11 +647,11 @@ state active
             list lSettings = llParseString2List(sStr, ["_"],[]);
             string sTok = llList2String(lSettings,0);
             string sVar = llList2String(lSettings,1);
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
-            
+
+
             if(sTok=="global"){
                 if(sVar == "locked") g_iLocked=FALSE;
             }else if(sTok == "anim"){
@@ -704,9 +703,9 @@ state inUpdate{
             llResetScript();
         }else if(iNum == 0){
             if(sMsg == "do_move" && !g_iIsMoving){
-                
+
                 if(llGetLinkNumber()==LINK_ROOT || llGetLinkNumber() == 0)return;
-                
+
                 g_iIsMoving=TRUE;
                 llOwnerSay("Moving oc_anim!");
                 integer i=0;
@@ -726,7 +725,7 @@ state inUpdate{
                         }
                     }
                 }
-                
+
                 llRemoveInventory(llGetScriptName());
             }
         }

--- a/src/collar/oc_api.lsl
+++ b/src/collar/oc_api.lsl
@@ -8,7 +8,7 @@ Aria (Tashia Redrose)
 Felkami (Caraway Ohmai)
     *Dec 2020   -   Fix: 457Switched optin from searching by string to list
 Medea (Medea Destiny)
-    *June 2021  -   Fix issue #566  setgroup not clearing properly, 
+    *June 2021  -   Fix issue #566  setgroup not clearing properly,
                 -   Fix issue #562, #381, #495 allow owners to permit wearers to set trusted/block
                 -   Fix issue #579 Add interface channel to DoListeners() function so Highlander works again
                 -   Issue #579 Restored menuto function to interface channel for backwards compatibility
@@ -17,11 +17,11 @@ Medea (Medea Destiny)
     *Aug 2022   -   Issue #843 & #774 fixes to check g_kOwner rather than CMD_WEARER. This fixes runaway
                     menu for wearers set as trusted (fix typo in menu too). Also wearer adding to trusted/
                     blacklist when permitted when also trusted (issue #849)
-                -   Fixed instance where interface channel is 0, also streamlined function, fix issue #819 
+                -   Fixed instance where interface channel is 0, also streamlined function, fix issue #819
                 -   Prefix reset now works, and notifications sent when changing prefix.
-Yosty7b3        
+Yosty7b3
     *Oct 2021   -   Remove unused StrideOfList() function.
-    *Feb 2022   -   Only reset when needed (part of boot speedup project).                              
+    *Feb 2022   -   Only reset when needed (part of boot speedup project).
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -104,7 +104,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 string SLURL(key kID){
@@ -134,18 +134,17 @@ integer CalcAuth(key kID) {
             if(g_kGroup!=NULL_KEY) {
                 if(llSameGroup(kID))return CMD_GROUP;
             }
-        
+
             if(g_iPublic) {
               return CMD_EVERYONE;
             }
         }
     }
-    
+
     return CMD_NOACCESS;
 }
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 integer NOTIFY = 1002;
 integer NOTIFY_OWNERS=1003;
@@ -173,10 +172,10 @@ PrintAccess(key kID){
     }
     sFinal+="\n";
     if(llGetListLength(g_lOwner)==0 || llListFindList(g_lOwner, [(string)g_kWearer])!=-1)sFinal+="\n* Wearer is unowned or owns themselves.\nThe wearer has owner access";
-    
+
     sFinal += "\nPublic: "+tf(g_iPublic);
     if(g_kGroup != NULL_KEY) sFinal+="\nGroup: secondlife:///app/group/"+(string)g_kGroup+"/about";
-    
+
     if(!g_iRunaway)sFinal += "\n\n* RUNAWAY IS DISABLED *";
     llMessageLinked(LINK_SET,NOTIFY, "0"+sFinal,kID);
     //llSay(0, sFinal);
@@ -198,7 +197,7 @@ RunawayMenu(key kID, integer iAuth){
     if(iAuth == CMD_OWNER || kID == g_kWearer){
         string sPrompt = "\n[Runaway]\n\nAre you sure you want to runaway from all owners?\n\n* This action will reset your owners list, trusted list, and your blocked avatars list.";
         list lButtons = ["Yes", "No"];
-        
+
         if(iAuth == CMD_OWNER){
             sPrompt+="\n\nAs the owner you have the ability to disable or enable runaway.";
             if(g_iRunaway)lButtons+=["Disable"];
@@ -279,7 +278,7 @@ UpdateLists(key kID, key kIssuer){
                     WearerConfirmListUpdate(kIssuer, "Removal of self ownership");
                 }
             }
-        } 
+        }
         if(iMode&ACTION_TRUST){
             if(llListFindList(g_lTrust, [(string)kID])!=-1){
                 if(kID != g_kWearer || g_iGrantedConsent || kIssuer==g_kWearer){
@@ -332,15 +331,15 @@ UserCommand(integer iAuth, string sCmd, key kID){
         g_iRunawayMode=0;
         RunawayMenu(kID,iAuth);
     }
-    
+
     if(iAuth == CMD_OWNER || (kID==g_kWearer && g_iAllowWearerSetTrusted==TRUE) ){
-          
+
         list lCmd = llParseString2List(sCmd, [" "],[]);
         string sCmdx = llToLower(llList2String(lCmd,0));
         if(sCmdx == "add" || sCmdx == "rem" ) {
             string sType = llToLower(llList2String(lCmd,1));
             string sID;
-            if(llGetListLength(lCmd)==3) sID = llList2String(lCmd,2);      
+            if(llGetListLength(lCmd)==3) sID = llList2String(lCmd,2);
             g_kMenuUser=kID;
             g_iCurrentAuth = iAuth;
             if(sCmdx=="add")
@@ -350,7 +349,7 @@ UserCommand(integer iAuth, string sCmd, key kID){
             else if(sType == "trust")g_iMode = g_iMode|ACTION_TRUST;
             else if(sType == "block")g_iMode=g_iMode|ACTION_BLOCK;
             else return; // Invalid, don't continue
-                    
+
             if(sID == ""){
                 // Open Scanner Menu to add
                 if(g_iMode&ACTION_ADD){
@@ -361,7 +360,7 @@ UserCommand(integer iAuth, string sCmd, key kID){
                     if(sType == "owner")lOpts=g_lOwner;
                     else if(sType == "trust")lOpts=g_lTrust;
                     else if(sType == "block")lOpts=g_lBlock;
-                    
+
                     Dialog(kID, "OpenCollar\n\nRemove "+sType, lOpts, [UPMENU],0,iAuth,"removeUser");
                 }
             }else {
@@ -370,11 +369,11 @@ UserCommand(integer iAuth, string sCmd, key kID){
         }
         else if(iAuth==CMD_OWNER) {
             if(sCmd == "safeword-disable")g_iSafewordDisable=TRUE;
-            else if(sCmd == "safeword-enable")g_iSafewordDisable=FALSE;        
+            else if(sCmd == "safeword-enable")g_iSafewordDisable=FALSE;
             if(sCmdx == "channel"){
                 g_iChannel = (integer)llList2String(lCmd,1);
                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_channel="+(string)g_iChannel, kID);
-        
+
             } else if(sCmdx == "prefix"){
                 if(llList2String(lCmd,1)==""){
                     llMessageLinked(LINK_SET,NOTIFY,"0The prefix is currently set to: "+g_sPrefix+". If you wish to change it, supply the new prefix to this same command", kID);
@@ -384,8 +383,8 @@ UserCommand(integer iAuth, string sCmd, key kID){
                 if(llToLower(g_sPrefix)=="reset") g_sPrefix = llToLower(llGetSubString(llKey2Name(llGetOwner()),0,1));
                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_prefix="+g_sPrefix,kID);
                 llMessageLinked(LINK_SET,NOTIFY,"1Prefix has been set to "+g_sPrefix+".",kID);
-            } 
-        } 
+            }
+        }
     }
     if (iAuth <CMD_OWNER || iAuth>CMD_EVERYONE) return;
     if (iAuth == CMD_OWNER && sCmd == "runaway") {
@@ -399,9 +398,9 @@ UserCommand(integer iAuth, string sCmd, key kID){
             llMessageLinked(LINK_SET, NOTIFY, "0Runaway complete", g_kWearer);
             return;
         }
-            
+
     }
-    
+
      if(sCmd == "print auth"){
          if(iAuth == CMD_OWNER || iAuth == CMD_TRUSTED || iAuth == CMD_WEARER)
             PrintAccess(kID);
@@ -470,15 +469,15 @@ state active
         llSleep(0.5);
         llRegionSayTo(g_kWearer, g_iInterfaceChannel, "OpenCollar=Yes");
         DoListeners();
-        
+
         llSetTimerEvent(15);
-        
+
         llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "ALL","");
-        
-            
-        
+
+
+
     }
-    
+
     timer(){
         if(llGetInventoryType("oc_states")==INVENTORY_NONE)llSetTimerEvent(0); // The state manager is not installed.
         if(llGetScriptState("oc_states")==FALSE){
@@ -487,15 +486,15 @@ state active
             llSetScriptState("oc_states",TRUE);
         }
     }
-    
-    
+
+
     run_time_permissions(integer iPerm) {
         if (iPerm & PERMISSION_ATTACH) {
             llOwnerSay("@detach=yes");
             llDetachFromAvatar();
         }
     }
-    
+
     listen(integer c,string n,key i,string m){
         if(c == g_iInterfaceChannel && llGetOwnerKey(i)==g_kWearer){
             //do nothing if wearer isnt owner of the object
@@ -515,9 +514,9 @@ state active
                 return;
             }
         }
-            
-        
-        
+
+
+
         if(llToLower(llGetSubString(m,0,llStringLength(g_sPrefix)-1))==llToLower(g_sPrefix)){
             string CMD=llGetSubString(m,llStringLength(g_sPrefix),-1);
             if(llGetSubString(CMD,0,0)==" ")CMD=llDumpList2String(llParseString2List(CMD,[" "],[]), " ");
@@ -529,18 +528,18 @@ state active
         } else {
             list lTmp = llParseString2List(m,[" ","(",")"],[]);
             string sDump = llToLower(llDumpList2String(lTmp, ""));
-            
+
             if(sDump == llToLower(g_sSafeword) && !g_iSafewordDisable && i == g_kWearer){
                 llMessageLinked(LINK_SET, CMD_SAFEWORD, "","");
                 SW();
             }
         }
     }
-    
+
     link_message(integer iSender, integer iNum, string sStr, key kID){
-        
-        
-        
+
+
+
         //if(iNum>=CMD_OWNER && iNum <= CMD_NOACCESS) llOwnerSay(llDumpList2String([iSender, iNum, sStr, kID], " ^ "));
         if(iNum == CMD_ZERO){
             if(sStr == "initialize")return;
@@ -552,20 +551,20 @@ state active
             //llOwnerSay("{API} Calculate auth for "+(string)kID+"="+(string)iAuth+";"+sStr);
             llMessageLinked(LINK_SET, AUTH_REPLY, "AuthReply|"+(string)kID+"|"+(string)iAuth,sStr);
         } else if(iNum >= CMD_OWNER && iNum <= CMD_NOACCESS) UserCommand(iNum, sStr, kID);
-            
+
         else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(iMenuIndex!=-1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         }
         else if(iNum == LM_SETTING_RESPONSE){
             list lPar = llParseString2List(sStr, ["_","="],[]);
             string sToken = llList2String(lPar,0);
             string sVar = llList2String(lPar,1);
             string sVal = llList2String(lPar,2);
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sToken+"_"+sVar]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             if(sToken == "auth"){
                 if(sVar == "owner"){
                     g_lOwner=llParseString2List(sVal, [","],[]);
@@ -578,7 +577,7 @@ state active
                 } else if(sVar == "group"){
                     if(sVal == (string)NULL_KEY)sVal="";
                     g_kGroup = (key)sVal;
-                    
+
                     if(g_kGroup!="")
                         llOwnerSay("@setgroup:"+(string)g_kGroup+"=force,setgroup=n");
                     else llOwnerSay("@setgroup=y");
@@ -606,7 +605,7 @@ state active
                     DoListeners();
                 }
             }
-            
+
             if(sStr=="settings=sent"){
                 if(g_iStartup){
                     g_iStartup=0;
@@ -619,20 +618,20 @@ state active
                             if(owner==g_kWearer)lMsg += "Yourself";
                             else lMsg += ["secondlife:///app/agent/"+(string)owner+"/about"];
                         }
-                        
+
                         llMessageLinked(LINK_SET, NOTIFY, "0You are owned by: "+llDumpList2String(lMsg,", "), g_kWearer);
                     }
                 }
             }
         } else if(iNum == LM_SETTING_DELETE){
-            
+
             list lPar = llParseString2List(sStr, ["_"],[]);
             string sToken = llList2String(lPar,0);
             string sVar = llList2String(lPar,1);
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             if(sToken == "auth"){
                 if(sVar == "owner"){
                     g_lOwner=[];
@@ -652,7 +651,7 @@ state active
                 } else if(sVar == "runaway"){
                     g_iRunaway=TRUE;
                 } else if(sVar == "wearertrust"){
-                    g_iAllowWearerSetTrusted=FALSE; 
+                    g_iAllowWearerSetTrusted=FALSE;
                 }
             } else if(sToken == "global"){
                 if(sVar == "channel"){
@@ -674,13 +673,13 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
                 //integer iRespring=TRUE;
-                
+
                 if(sMenu == "scan~add"){
                     if(sMsg == UPMENU){
                         llMessageLinked(LINK_SET, iAuth, "menu Access", kAv);
@@ -750,19 +749,19 @@ state active
                             llMessageLinked(LINK_SET, CMD_OWNER, "runaway", g_kWearer);
                             llMessageLinked(LINK_SET, CMD_SAFEWORD, "safeword", "");
                             llMessageLinked(LINK_SET, CMD_OWNER, "clear", g_kWearer);
-                            
+
                             llMessageLinked(LINK_SET, TIMEOUT_REGISTER, "5", "spring_access:"+(string)kAv);
                         }
                     }
                 } else if(sMenu=="confirmdenyrunaway") {
                     if(sMsg=="Accept"){
                         g_iRunaway=FALSE;
-                        llMessageLinked(LINK_SET, LM_SETTING_SAVE, "AUTH_runaway=0", "origin"); 
+                        llMessageLinked(LINK_SET, LM_SETTING_SAVE, "AUTH_runaway=0", "origin");
                         llMessageLinked(LINK_SET, TIMEOUT_REGISTER, "2", "spring_access:"+(string)g_kDenyRunawayRequester);
                     } else if (sMsg=="Deny"){
                         llMessageLinked(LINK_SET, NOTIFY, "Wearer has DENIED switching off runaway.",g_kDenyRunawayRequester);
                         llMessageLinked(LINK_SET, TIMEOUT_REGISTER, "2", "spring_access:"+(string)g_kDenyRunawayRequester);
-                    }             
+                    }
                 }
             }
         } else if(iNum == RLV_REFRESH){
@@ -787,18 +786,18 @@ state active
                 //llSay(0, "scan: "+(string)i+";"+(string)llGetListLength(lPeople)+";"+(string)g_iMode);
                 if(llDetectedKey(i)!=llGetOwner())
                     lPeople += llDetectedKey(i);
-                
+
             } else {
                 //llSay(0, "scan: invalid list length: "+(string)llGetListLength(lPeople)+";"+(string)g_iMode);
             }
         }
-        
+
         Dialog(g_kMenuUser, "OpenCollar\nAdd Menu", lPeople, [">Wearer<",UPMENU], 0, g_iCurrentAuth, "scan~add");
     }
-    
+
     no_sensor(){
         if(!(g_iMode&ACTION_SCANNER))return;
-        
+
         Dialog(g_kMenuUser, "OpenCollar\nAdd Menu", [], [">Wearer<", UPMENU], 0, g_iCurrentAuth, "scan~add");
     }
 }

--- a/src/collar/oc_bell.lsl
+++ b/src/collar/oc_bell.lsl
@@ -1,8 +1,8 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2009 - 2016 Cleo Collins, Nandana Singh, Satomi Ahn,   
-// Joy Stipe, Wendy Starfall, Medea Destiny, littlemousy,         
-// Romka Swallowtail, Garvin Twine et al.  
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2009 - 2016 Cleo Collins, Nandana Singh, Satomi Ahn,
+// Joy Stipe, Wendy Starfall, Medea Destiny, littlemousy,
+// Romka Swallowtail, Garvin Twine et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 
 //scans for sounds starting with: bell_
@@ -33,7 +33,6 @@ integer TIMEOUT_FIRED = 30499;
 string g_sSubMenu = "Bell";
 string g_sParentMenu = "Apps";
 list g_lMenuIDs;  //three strided list of avkey, dialogid, and menuname
-integer g_iMenuStride = 3;
 
 float g_fVolume=0.5; // volume of the bell
 float g_fVolumeStep=0.1; // stepping for volume
@@ -117,7 +116,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     key kMenuID = llGenerateKey();
     llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, iMenuType], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, iMenuType], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, iMenuType];
 }
 
@@ -332,7 +331,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if (~iMenuIndex) {
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 list lMenuParams = llParseString2List(sStr, ["|"], []);
                 key kAV = llList2String(lMenuParams, 0);
                 string sMessage = llList2String(lMenuParams, 1);
@@ -377,15 +376,15 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
-        
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
+
         } else if (iNum == LM_SETTING_RESPONSE) {
             list lParam = llParseString2List(sStr,["_","="],[]);
             string sToken = llList2String(lParam,0);
             string sVar = llList2String(lParam,1);
             string sValue = llList2String(lParam,2);
-            
-            
+
+
             if (sToken == "bell") {
                 //llOwnerSay("Process bell settings: "+sStr);
                 if (sVar == "on") {
@@ -411,7 +410,7 @@ state active
                     SetBellElementAlpha();
                 }
             }
-        
+
         } else if(iNum == CMD_OWNER && sStr == "runaway") {
             llSleep(4);
             SetBellElementAlpha();
@@ -424,7 +423,7 @@ state active
             DebugOutput(kID, [" HAS BELL PRIMS:", g_iHasBellPrims]);
             DebugOutput(kID, [" BELL VISIBLE:", g_iBellShow]);
             DebugOutput(kID, [" BELL ON:", g_iBellOn]);
-        } 
+        }
     }
 
     control( key kID, integer nHeld, integer nChange ) {

--- a/src/collar/oc_bookmarks.lsl
+++ b/src/collar/oc_bookmarks.lsl
@@ -1,8 +1,8 @@
 // oc_bookmarks
 // This file is part of OpenCollar.
-// Copyright (c) 2008 - 2021 Satomi Ahn, Nandana Singh, Wendy Starfall,  
-// Sumi Perl, Master Starship, littlemousy, mewtwo064, ml132,       
-// Romka Swallowtail, Garvin Twine, Medea Destiny et al.                 
+// Copyright (c) 2008 - 2021 Satomi Ahn, Nandana Singh, Wendy Starfall,
+// Sumi Perl, Master Starship, littlemousy, mewtwo064, ml132,
+// Romka Swallowtail, Garvin Twine, Medea Destiny et al.
 // Licensed under the GPLv2.  See LICENSE for full details.
 /*
 Medea Destiny -
@@ -44,7 +44,6 @@ integer g_iRLVOn                      = FALSE; //Assume RLV is off until we hear
 string g_tempLoc                      = "";   //This holds a global temp location for manual entry from provided location but no favorite name - g_kTBoxIdLocationOnly
 
 list g_lMenuIDs;//3-strided list of avkey, dialogid, menuname
-integer g_iMenuStride = 3;
 
 key     g_kWearer;
 
@@ -103,7 +102,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     key kMenuID = llGenerateKey();
     llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, sMenuType];
 }
 
@@ -354,9 +353,9 @@ TeleportTo(string sStr,key kIssuer) {  //take a string in region (x,y,z) format,
         llMapDestination(sRegion, g_vLocalPos, ZERO_VECTOR);
     else  //We've got RLV, let's use it
         g_kRequestHandle = llRequestSimulatorData(sRegion, DATA_SIM_POS);
-        llRegionSayTo(kIssuer,0,"Sending "+llGetDisplayName(g_kWearer)+" to http://maps.secondlife.com/secondlife/"+sRegion+"/"+(string)((integer)g_vLocalPos.x) + "/"+(string)((integer)g_vLocalPos.y)+"/"+(string)((integer)g_vLocalPos.z)+".");   
-    
-   
+        llRegionSayTo(kIssuer,0,"Sending "+llGetDisplayName(g_kWearer)+" to http://maps.secondlife.com/secondlife/"+sRegion+"/"+(string)((integer)g_vLocalPos.x) + "/"+(string)((integer)g_vLocalPos.y)+"/"+(string)((integer)g_vLocalPos.z)+".");
+
+
 }
 
 PrintDestinations(key kID) {  // On inventory change, re-read our ~destinations notecard
@@ -405,7 +404,7 @@ default
         }
     }
 }
-state active 
+state active
 {
     on_rez(integer iStart) {
         llResetScript();
@@ -493,10 +492,10 @@ state active
         else if(iNum == LM_SETTING_RESPONSE) {
             list lParams = llParseString2List(sStr, ["="], []);
             string sToken = llList2String(lParams, 0);
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sToken]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             string sValue = llList2String(lParams, 1);
             integer i = llSubStringIndex(sToken, "_");
             if(llGetSubString(sToken, 0, i) == g_sSettingToken) {
@@ -507,27 +506,27 @@ state active
                 }
             }
         } else if(iNum == LM_SETTING_EMPTY){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
         } else if(iNum == LM_SETTING_DELETE){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
         } else if (iNum >= CMD_OWNER && iNum <= CMD_WEARER && iNum != CMD_GROUP) UserCommand(iNum, sStr, kID); // This is intentionally not available to public access.
         else if( (iNum == CMD_EVERYONE || iNum == CMD_GROUP) && (llToLower(sStr)==llToLower(g_sSubMenu) || llToLower(sStr) == "menu "+llToLower(g_sSubMenu)) ){
             //Test if this is a denied auth
             llMessageLinked(LINK_SET,NOTIFY, "0%NOACCESS% to bookmarks", kID);
         } else if(iNum == DIALOG_RESPONSE) {
-        
+
             //Test to see if this is a denied auth. If we're here and its denied, we respring. A CMD_* call is already sent out which will produce the NOTIFY
             //We're hard coding page 0 because new menu calls should always be page 0
             if((llSubStringIndex(sStr, g_sSubMenu + "|0|" + (string)CMD_EVERYONE) != -1) || (llSubStringIndex(sStr, g_sSubMenu + "|0|" + (string)CMD_GROUP) != -1)){
                 llMessageLinked(LINK_SET, CMD_EVERYONE, "menu "+g_sParentMenu, llGetSubString(sStr, 0, 35));
             }
-            
+
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if (iMenuIndex != -1) {
                 list lMenuParams = llParseStringKeepNulls(sStr, ["|"], []);
@@ -536,7 +535,7 @@ state active
                 // integer iPage = (integer)llList2String(lMenuParams, 2); // menu page
                 integer iAuth = (integer)llList2String(lMenuParams, 3); // auth level of avatar
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if(sMenuType == "TextBoxIdLocation") {
                     if(sMessage != " ")
                         addDestination(sMessage, g_tempLoc, kID);
@@ -580,7 +579,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if (~iMenuIndex1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
         else if(iNum == LINK_CMD_DEBUG){
             integer onlyver=0;

--- a/src/collar/oc_core.lsl
+++ b/src/collar/oc_core.lsl
@@ -12,30 +12,30 @@ Medea (Medea Destiny)
                 -   added Wearer Trust option to Access Menu so that owners may allow or forbid
                     wearer from adding/removing to trusted and block lists
                 -   Moved Limit Range to Settings menu to make room in Access menu for above,
-                    as it seems logical to have this as a global setting. 
+                    as it seems logical to have this as a global setting.
                 -   Added explanatory text to settings menu prompt and access prompt,
-                -   Added safeword to help/about prompt. 
+                -   Added safeword to help/about prompt.
                 -   Fix issue #566, clear @setgroup when group unchecked properly.
-                -   Extention to above, Disallow setting group access when no group active.  
+                -   Extention to above, Disallow setting group access when no group active.
                 -   Fix issue #580 Limited printing settings to owner and wearer
                 -   #579 Added 'Listen 0' button to Settings menu that allows toggling channel 0
                     command listener on and off.
-    Sept 2021   -   Added sleep before notify for device name chage, issue #672 
+    Sept 2021   -   Added sleep before notify for device name chage, issue #672
                 -   Added confirmation messages when group or public access is toggled and fixed a typo
                 -   Efficiency pass, inlined majorminor(), docheckupdate() and docheckdevupdate().
 
                     Removed g_lTestReports, left over from alpha.
     Nov 2021    -   Auth check for hide didn't account for when wearer tries to use hide with AllowHiding
-                     ticked but access is not CMD_WEARER (i.e. wearer set to trusted). (see #774)                         
-    Jun 2022    -   Fixes for #774 (extension to above, allowing for wearer set to trusted). Using 
+                     ticked but access is not CMD_WEARER (i.e. wearer set to trusted). (see #774)
+    Jun 2022    -   Fixes for #774 (extension to above, allowing for wearer set to trusted). Using
                     kID == g_kWearer instead of iNum==CMD_WEARER in UserCommad() for:
                     Safeword report, verbosity level, locking
                     And kAv == g_kWearer instead of iAuth == CMD_WEARER in meu dialog responses for:
-                    + / - trusted / blacklist when wearer is permitted, displaying access list, print settings  
+                    + / - trusted / blacklist when wearer is permitted, displaying access list, print settings
     Oct 2022    -   Fix for full version>beta version checking. Added menu text to clarify versioning for beta users.
-                    
+
 Stormed Darkshade (StormedStormy)
-    March 2022  -   Added a button for reboot to help/about menu.  
+    March 2022  -   Added a button for reboot to help/about menu.
 
 Yosty7B3
     Nov 2022  -     Removed Setor() and bool() functions for streamlining.
@@ -119,7 +119,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 integer g_iHide=FALSE;
@@ -191,7 +191,7 @@ HelpMenu(key kID, integer iAuth){
     string EXTRA_VER_TXT;
     if(llGetSubString(COLLAR_VERSION,-1,-1)!="0") EXTRA_VER_TXT = " (ALPHA "+llGetSubString(COLLAR_VERSION,-1,-1)+") ";
     if(llGetSubString(COLLAR_VERSION,-2,-2)!="0") EXTRA_VER_TXT += " (BETA "+llGetSubString(COLLAR_VERSION,-2,-2)+") ";
-    if(llGetSubString(COLLAR_VERSION,-3,-3)!="0") EXTRA_VER_TXT += " (RC " + llGetSubString(COLLAR_VERSION,-3,-3)+") ";  
+    if(llGetSubString(COLLAR_VERSION,-3,-3)!="0") EXTRA_VER_TXT += " (RC " + llGetSubString(COLLAR_VERSION,-3,-3)+") ";
 
     string sPrompt = "\nOpenCollar "+COLLAR_VERSION+" "+EXTRA_VER_TXT+"\nVersion: "+llList2String(["","(Newer than release)"],g_iAmNewer)+" "+llList2String(["(Most Current Version)","(Update Available)"],UPDATE_AVAILABLE);
     sPrompt += "\n\nDocumentation https://opencollar.cc";
@@ -370,7 +370,6 @@ integer g_iWaitUpdate;
 integer g_iUpdateChan = -7483213;
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 integer g_iLocked=FALSE;
 Compare(string V1, string V2){
     V2=llStringTrim(V2,STRING_TRIM);
@@ -500,7 +499,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -559,7 +558,7 @@ state active
                             if(g_kGroup!=""){
                                 g_kGroup="";
                                 llMessageLinked(LINK_SET, LM_SETTING_DELETE, "auth_group", "origin");
-                                llMessageLinked(LINK_SET,NOTIFY,"1Group Access has been turned off.",kAv); 
+                                llMessageLinked(LINK_SET,NOTIFY,"1Group Access has been turned off.",kAv);
                             }else{
                                 key t_kGroup = llList2Key(llGetObjectDetails(llGetKey(), [OBJECT_GROUP]),0);
                                 if(t_kGroup==NULL_KEY){
@@ -568,7 +567,7 @@ state active
                                 else{
                                     g_kGroup=t_kGroup;
                                      llMessageLinked(LINK_SET, LM_SETTING_SAVE, "auth_group="+(string)g_kGroup, "origin");
-                                     llMessageLinked(LINK_SET,NOTIFY,"1Group Access has been turned on.",kAv);   
+                                     llMessageLinked(LINK_SET,NOTIFY,"1Group Access has been turned on.",kAv);
                                 }
                             }
                         } else {
@@ -579,11 +578,11 @@ state active
                             g_iPublic=1-g_iPublic;
                             if(g_iPublic) {
                                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, "auth_public=1", "origin");
-                                llMessageLinked(LINK_SET,NOTIFY,"1Public Access has been turned on.",kAv); 
+                                llMessageLinked(LINK_SET,NOTIFY,"1Public Access has been turned on.",kAv);
                             } else {
                                 llMessageLinked(LINK_SET, LM_SETTING_DELETE, "auth_public","origin");
-                                llMessageLinked(LINK_SET,NOTIFY,"1Public Access has been turned off.",kAv); 
-                            } 
+                                llMessageLinked(LINK_SET,NOTIFY,"1Public Access has been turned off.",kAv);
+                            }
                         } else llMessageLinked(LINK_SET, NOTIFY, "0%NOACCESS% to changing public", kAv);
                     } else if(sMsg == "Runaway"){
                         llMessageLinked(LINK_SET,0,"menu runaway", kAv);
@@ -715,7 +714,7 @@ state active
             }
         }else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(iMenuIndex!=-1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             list lPar = llParseString2List(sStr, ["_","="],[]);
             string sToken = llList2String(lPar,0);

--- a/src/collar/oc_couples.lsl
+++ b/src/collar/oc_couples.lsl
@@ -1,8 +1,8 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2004 - 2021 Francis Chung, Ilse Mannonen, Nandana Singh, 
-// Cleo Collins, Satomi Ahn, Joy Stipe, Wendy Starfall, Garvin Twine,   
-// littlemousy, Romka Swallowtail, Sumi Perl et al. 
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2004 - 2021 Francis Chung, Ilse Mannonen, Nandana Singh,
+// Cleo Collins, Satomi Ahn, Joy Stipe, Wendy Starfall, Garvin Twine,
+// littlemousy, Romka Swallowtail, Sumi Perl et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 string g_sScriptVersion="8.1";
 integer LINK_CMD_DEBUG=1999;
 DebugOutput(key kID, list ITEMS){
@@ -18,8 +18,7 @@ DebugOutput(key kID, list ITEMS){
 string g_sParentMenu = "Animations";
 string g_sSubMenu = "Couples";
 string UPMENU = "BACK";
-list     g_lMenuIDs;
-integer g_iMenuStride = 3;
+list   g_lMenuIDs;
 
 integer g_iAnimTimeout;
 integer g_iPermissionTimeout;
@@ -135,7 +134,7 @@ Dialog(key kRCPT, string sPrompt, list lButtons, list lUtilityButtons, integer i
     } else
         llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lButtons, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuID], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuID], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, sMenuID];
 }
 
@@ -260,7 +259,7 @@ default
 }
 state active
 {
-    on_rez(integer iStart) 
+    on_rez(integer iStart)
     {
         //added to stop anims after relog when you logged off while in an endless couple anim
         if (g_sSubAnim != "" && g_sDomAnim != "") {
@@ -288,7 +287,7 @@ state active
         if (iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) {
             //the command was given by either owner, secowner, group member, wearer, or public user
             list lParams = llParseString2List(sStr, [" "], []);
-            g_kCmdGiver = kID; 
+            g_kCmdGiver = kID;
             g_iCmdAuth = iNum;
             string sCommand = llToLower(llList2String(lParams, 0));
             string sValue = llToLower(llList2String(lParams, 1));
@@ -304,7 +303,7 @@ state active
                     Dialog(g_kCmdGiver, "\nChoose a partner:\n", [sTmpName], ["BACK"], 0, iNum, "sensor");
                 } else {       //no name given.
                     if (kID == g_kWearer) {                   //if commander is not sub, then treat commander as partner
-                        llMessageLinked(LINK_SET, NOTIFY, 
+                        llMessageLinked(LINK_SET, NOTIFY,
                                                         "0"+"\n\nYou didn't give the name of the person you want to animate. To " + sCommand +
                                                         " Alice Mannonen, for example, you could say:\n\n /%CHANNEL% %PREFIX%" + sCommand + " ali\n", g_kWearer);
                     } else {               //else set partner to commander
@@ -335,10 +334,10 @@ state active
             list lParams = llParseString2List(sStr, ["="], []);
             string sToken = llList2String(lParams, 0);
             string sValue = llList2String(lParams, 1);
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sToken]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
             if(sToken == g_sSettingToken + "timeout")
                 g_fTimeOut = (float)sValue;
             else if (sToken == g_sSettingToken + "verbose")
@@ -346,15 +345,15 @@ state active
             else if (sToken == g_sGlobalToken+"devicename")
                 g_sDeviceName = sValue;
         } else if(iNum == LM_SETTING_EMPTY){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
         } else if(iNum == LM_SETTING_DELETE){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
         } else if (iNum == DIALOG_RESPONSE) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if (~iMenuIndex) {
@@ -364,7 +363,7 @@ state active
                 // integer iPage = (integer)llList2String(lMenuParams, 2);
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
                 string sMenu=llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if (sMenu == "couples") {
                     if (sMessage == UPMENU)
                         llMessageLinked(LINK_SET, iAuth, "menu " + g_sParentMenu, kAv);
@@ -414,7 +413,7 @@ state active
                     else if ((integer)sMessage > 0 && ((string)((integer)sMessage) == sMessage)) {
                         g_fTimeOut = (float)((integer)sMessage);
                         llMessageLinked(LINK_SET, LM_SETTING_SAVE, g_sSettingToken + "timeout=" + (string)g_fTimeOut, "");
-                        string sPet; 
+                        string sPet;
                         if (g_fTimeOut > 20.0)  sPet = "(except the \"pet\" sequence) ";
                         llMessageLinked(LINK_SET,NOTIFY,"1"+"Couple Anmiations "+sPet+"play now for " + (string)llRound(g_fTimeOut) + " seconds.",kAv);
                         CoupleAnimMenu(kAv, iAuth);
@@ -428,7 +427,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if (iNum == LOADPIN && sStr == llGetScriptName()) {
             integer iPin = (integer)llFrand(99999.0)+1;
             llSetRemoteScriptAccessPin(iPin);

--- a/src/collar/oc_folders.lsl
+++ b/src/collar/oc_folders.lsl
@@ -5,14 +5,14 @@ Copyright 2020
 Aria (Tashia Redrose)
     * Aug 2020      -           Rewrote oc_folders for 8.0 Alpha 5
 Medea (Medea Destiny)
-    * June 2021     -   *Fix issue #570, Allow hiding folders starting with ~ via HideTilde option, defaults to ON. 
+    * June 2021     -   *Fix issue #570, Allow hiding folders starting with ~ via HideTilde option, defaults to ON.
                         *Fix issue  #581, filtering input to UserCommand to only folder-auth check actual folder
-                        commands rather than folder-authing and processing EVERYTHING THE COLLAR DOES BY ANY USER 
+                        commands rather than folder-authing and processing EVERYTHING THE COLLAR DOES BY ANY USER
     * May 2022      -   *Fix issue #775, changed string handling to ensure command is not issued as part of search
                         term, added sanity checking for chat commands to ensure we don't try to search for nothing,
-                        and no longer operate on empty search results. Issuer of chat command now stored as 
+                        and no longer operate on empty search results. Issuer of chat command now stored as
                         g_kChatUser so they can be notified if findfolder fails.
-                         
+
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -71,7 +71,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -204,8 +204,8 @@ UserCommand(integer iNum, string sStr, key kID) {
         //string sText;
         if(sChangevalue==""){ // don't search for empty strings.
              llMessageLinked(LINK_SET, NOTIFY, "0You have to supply a string to search for to use add/remove/wear commands.", kID);
-             return; 
-        } 
+             return;
+        }
         g_kChatUser=kID;
         if(iNum == CMD_TRUSTED && !Bool((g_iAccessBitSet&1)))return R();
         if(iNum == CMD_EVERYONE && !Bool((g_iAccessBitSet&2)))return R();
@@ -237,7 +237,7 @@ UserCommand(integer iNum, string sStr, key kID) {
         sChangevalue = llStringTrim(llDeleteSubString(sStr, 0, 0), STRING_TRIM);
         if(sChangevalue==""){ // don't search for empty strings.
              llMessageLinked(LINK_SET, NOTIFY, "0You have to supply a string to search for to use add/remove/wear commands.", kID);
-             return; 
+             return;
         }
         if(sChangetype == "&"){
             // add folder path
@@ -268,7 +268,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -399,7 +398,7 @@ state active
         {
             if(llStringTrim(sMsg,STRING_TRIM)==""){
                  llMessageLinked(LINK_SET, NOTIFY, "0Nothing matching that term was found in #RLV!", g_kChatUser);
-                 return; // don't do anything if 
+                 return; // don't do anything if
             } if(g_iCmdMode & F_RECURSIVE){
                 if(g_iCmdMode & F_ADD){
                     llOwnerSay("@attachallover:"+sMsg+"=force");
@@ -432,7 +431,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -540,7 +539,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(iMenuIndex!=-1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);
@@ -561,7 +560,7 @@ state active
                 } else if(llList2String(lSettings,1) =="hidetilde"){
                     g_iHideTilde=(integer)llList2String(lSettings,2);
                 }
-                
+
             }
         } else if(iNum == REPLY_FOLDER_LOCKS)
         {

--- a/src/collar/oc_label.lsl
+++ b/src/collar/oc_label.lsl
@@ -63,7 +63,6 @@ string g_sFontMenu = "Font";
 string g_sColorMenu = "Color";
 
 list g_lMenuIDs;  //three strided list of avkey, dialogid, and menuname
-integer g_iMenuStride = 3;
 
 //key g_kDialogID;
 //key g_kTBoxID;
@@ -325,7 +324,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     //Debug("Made menu.");
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, iMenuType], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, iMenuType], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, iMenuType];
 }
 
@@ -513,7 +512,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if (~iMenuIndex) {
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 list lMenuParams = llParseString2List(sStr, ["|"], []);
                 key kAv = (key)llList2String(lMenuParams, 0);
                 string sMessage = llList2String(lMenuParams, 1);
@@ -567,7 +566,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
         else if(iNum == LINK_CMD_DEBUG){
             integer onlyver=0;

--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -1,9 +1,9 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2008 - 2016 Nandana Singh, Lulu Pink, Garvin Twine,    
-// Joy Stipe, Cleo Collins, Satomi Ahn, Master Starship, Toy Wylie,    
-// Kaori Gray, Sei Lisa, Wendy Starfall, littlemousy, Romka Swallowtail,  
-// Sumi Perl, Karo Weirsider, Kurt Burleigh, Marissa Mistwallow et al.   
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2008 - 2016 Nandana Singh, Lulu Pink, Garvin Twine,
+// Joy Stipe, Cleo Collins, Satomi Ahn, Master Starship, Toy Wylie,
+// Kaori Gray, Sei Lisa, Wendy Starfall, littlemousy, Romka Swallowtail,
+// Sumi Perl, Karo Weirsider, Kurt Burleigh, Marissa Mistwallow et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 string g_sScriptVersion = "8.1";
 integer LINK_CMD_DEBUG=1999;
 
@@ -18,7 +18,7 @@ string TOK_DEST     = "leashedto"; // format: uuid,rank
 //integer TIMEOUT_READY = 30497;
 //integer TIMEOUT_REGISTER = 30498;
 //integer TIMEOUT_FIRED = 30499;
- 
+
 //MESSAGE MAP
 //integer CMD_ZERO = 0;
 integer CMD_OWNER = 500;
@@ -73,7 +73,6 @@ string BUTTON_SUBMENU      = "Leash";
 // ------ VARIABLE DEFINITIONS ------
 // ----- menu -----
 list     g_lMenuIDs;
-integer g_iMenuStride = 3;
 integer g_iPreviousAuth;
 key g_kLeashCmderID;
 
@@ -141,7 +140,7 @@ Dialog(key kRCPT, string sPrompt, list lButtons, list lUtilityButtons, integer i
     key kMenuID = llGenerateKey();
     llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lButtons, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuID], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuID], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, sMenuID];
 }
 
@@ -150,7 +149,7 @@ SensorDialog(key kRCPT, string sPrompt, string sSearchName, integer iAuth, strin
     if (sSearchName != "") sSearchName = "`"+sSearchName+"`1";
     llMessageLinked(LINK_SET, SENSORDIALOG, (string)kRCPT +"|"+sPrompt+"|0|``"+(string)iSensorType+"`10`"+(string)PI+sSearchName+"|"+BUTTON_UPMENU+"|" + (string)iAuth, kMenuID);
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuID], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuID], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, sMenuID];
 }
 
@@ -169,7 +168,7 @@ ConfirmDialog(key kAv, key kCmdGiver, string sType, integer iAuth) {
         if (kCmdGiver == g_kWearer) sPrompt += "pass you their leash.";
         else sPrompt += "pass you %WEARERNAME%'s leash.";
         sPrompt += "\n\nAre you OK with this?";
-        
+
         Dialog(kAv,sPrompt,["Yes","No"],[],0,iAuth,"LeashTargetConfirm");
     } else {
         sMessage = "Asking "+NameURI(kAv)+" to accept %WEARERNAME% to follow them.";
@@ -210,7 +209,7 @@ ApplyRestrictions() {
                 //llSay(0, "RLV_CMD issue: no fly, notp");
                 llMessageLinked(LINK_SET, RLV_CMD, "fly=n,tplm=n,tplure=n,tploc=n,tplure:" + (string) g_kLeashedTo + "=add,fartouch=n,sittp=n", "realleash");     //set all restrictions
                 return;
-                
+
             }
         //} else {
             //Debug("Strict is off");
@@ -243,7 +242,7 @@ integer LeashTo(key kTarget, key kCmdGiver, integer iAuth, list lPoints, integer
 
     integer bCmdGiverIsAvi=llGetAgentSize(kCmdGiver) != ZERO_VECTOR;
     integer bTargetIsAvi=llGetAgentSize(kTarget) != ZERO_VECTOR;
-    
+
     // Send notices to wearer, leasher, and target
     // Only send notices if Leasher is an AV, as objects normally handle their own messages for such things
     if (bCmdGiverIsAvi) {
@@ -326,7 +325,7 @@ DoLeash(key kTarget, integer iAuth, list lPoints, integer bSave) {
         llMessageLinked(LINK_SET, CMD_PARTICLE, "leash" + g_sCheck + "|" + (string)g_bLeashedToAvi, g_kLeashedTo);
     }
     llSetTimerEvent(3.0);   //check for leasher out of range
-    
+
     // change to llTarget events by Lulu Pink
     g_vPos = llList2Vector(llGetObjectDetails(g_kLeashedTo, [OBJECT_POS]), 0);
     //to prevent multiple target events and llMoveToTargets
@@ -338,7 +337,7 @@ DoLeash(key kTarget, integer iAuth, list lPoints, integer bSave) {
         llMessageLinked(LINK_SET, LM_SETTING_SAVE, g_sSettingToken + TOK_DEST + "name=" + g_sLeashedToName , "");
         llMessageLinked(LINK_SET, LM_SETTING_SAVE, g_sSettingToken + TOK_DEST + "=" + (string)kTarget + "," + (string)iAuth + "," + (string)g_bLeashedToAvi + "," + (string)g_bFollowMode, "");
     }
-    
+
     g_iLeasherInRange=TRUE;
     ApplyRestrictions();
 }
@@ -691,7 +690,7 @@ state active
         vector vLeashedToPos=llList2Vector(llGetObjectDetails(g_kLeashedTo,[OBJECT_POS]),0);
         integer iIsInSimOrJustOutside=TRUE;
         if(vLeashedToPos == ZERO_VECTOR || llVecDist(llGetPos(), vLeashedToPos)> 255) iIsInSimOrJustOutside=FALSE;
-        
+
         if (iIsInSimOrJustOutside && llVecDist(llGetPos(),vLeashedToPos)<(60+g_iLength)) {   //if the leasher is now in range
             dtext("timer : iIsInSimOrJustOutside && VecDist < (60+(iLength=3))");
             if(!g_iLeasherInRange) { //and the leasher was previously not in range
@@ -700,7 +699,7 @@ state active
                     llSetTimerEvent(3.0);
                 }
                 //Debug("leashing with "+g_sCheck);
-                
+
                 if(!g_bFollowMode)
                     llMessageLinked(LINK_SET, CMD_PARTICLE, "leash" + g_sCheck + "|" + (string)g_bLeashedToAvi, g_kLeashedTo);
                 g_iLeasherInRange = TRUE;
@@ -711,7 +710,7 @@ state active
                 g_iTargetHandle = llTarget(g_vPos, (float)g_iLength);
                 if (g_vPos != ZERO_VECTOR) llMoveToTarget(g_vPos, 0.8);
                 ApplyRestrictions();
-                
+
                 if(!g_iAlreadyMoving) llMessageLinked(LINK_SET, LEASH_START_MOVEMENT,"","");
             } else {
                 dtext("timer : LeasherInRange = TRUE");
@@ -763,12 +762,12 @@ state active
             string sToken = llGetSubString(sMessage, 0, iInd -1);
             string sValue = llGetSubString(sMessage, iInd + 1, -1);
             integer i = llSubStringIndex(sToken, "_");
-            
-            
+
+
             //integer ind = llListFindList(g_lSettingsReqs, [sToken]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
-            
+
+
             if (llGetSubString(sToken, 0, i) == g_sSettingToken) {
                 //Debug("got Leash settings:"+sMessage);
                 sToken = llGetSubString(sToken, i + 1, -1);
@@ -794,17 +793,17 @@ state active
                 } else if (sToken == "turn") g_iTurnModeOn = (integer)sValue;
                 else if(sToken == TOK_DEST+"name") g_sLeashedToName = sValue;
             }
-        
+
         } else if(iNum == LM_SETTING_EMPTY){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sMessage]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
         } else if(iNum == LM_SETTING_DELETE){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sMessage]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
         } else if (iNum == RLV_ON) {
             g_iRLVOn = TRUE;
             ApplyRestrictions();
@@ -822,7 +821,7 @@ state active
                 //integer iPage = (integer)llList2String(lMenuParams, 2);
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
                 string sMenu=llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if (sMenu == "MainDialog"){
                     if (sButton == BUTTON_UPMENU)
                         llMessageLinked(LINK_SET, iAuth, "menu "+BUTTON_PARENTMENU, kAV);
@@ -835,7 +834,7 @@ state active
                 // added for Confirmation Request 15-04-17 Otto
                 else if (sMenu == "LeashTarget") {
                     g_kLeashCmderID = (key)sButton;
-                    
+
                     g_iPassConfirmed = TRUE;
                     if (g_kLeashCmderID == g_kWearer) iAuth = CMD_WEARER;
                     //UserCommand(iAuth, "pass " + sButton, kAV, TRUE);
@@ -872,7 +871,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kMessageID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
         } else if (iNum == REBOOT && sMessage == "reboot") llResetScript();
         else if(iNum == AUTH_REPLY){
             list lParams = llParseString2List(sMessage, ["|"],[]);
@@ -903,7 +902,7 @@ state active
 
     at_target(integer iNum, vector vTarget, vector vMe) {
         llStopMoveToTarget();
-        
+
         llTargetRemove(g_iTargetHandle);
         g_vPos = llList2Vector(llGetObjectDetails(g_kLeashedTo,[OBJECT_POS]),0);
         g_iTargetHandle = llTarget(g_vPos, (float)g_iLength);
@@ -913,7 +912,7 @@ state active
             if (g_iTurnModeOn) llMessageLinked(LINK_SET, RLV_CMD, "setrot:" + (string)(turnAngle) + "=force", NULL_KEY);   //transient command, doesn;t need our fakekey
             g_iJustMoved = 0;
         }
-        
+
         if(g_iAlreadyMoving) llMessageLinked(LINK_SET, LEASH_END_MOVEMENT, "","");
     }
 
@@ -930,8 +929,8 @@ state active
             }
             if (g_vPos != ZERO_VECTOR){
                 // The below code was causing users to fly if the z height of the person holding the leash was different.
-                
-                
+
+
                 //vector currentPos = llGetPos();
                 //g_vPos = <g_vPos.x, g_vPos.y, currentPos.z>;
                 llMoveToTarget(g_vPos,1.0);
@@ -940,8 +939,8 @@ state active
                 llStopMoveToTarget();
                 llTargetRemove(g_iTargetHandle);
             }
-            
-            
+
+
             if(!g_iAlreadyMoving) llMessageLinked(LINK_SET, LEASH_START_MOVEMENT, "","");
         } else {
             llStopMoveToTarget();

--- a/src/collar/oc_meshlabel.lsl
+++ b/src/collar/oc_meshlabel.lsl
@@ -1,17 +1,17 @@
 // This file is part of OpenCollar.
-// Copyright (c) 2006 - 2016 Xylor Baysklef, Kermitt Quirk,        
-// Thraxis Epsilon, Gigs Taggart, Strife Onizuka, Huney Jewell,      
-// Salahzar Stenvaag, Lulu Pink, Nandana Singh, Cleo Collins, Satomi Ahn, 
-// Joy Stipe, Wendy Starfall, Romka Swallowtail, littlemousy,       
-// Garvin Twine et al.   
-// Licensed under the GPLv2.  See LICENSE for full details. 
+// Copyright (c) 2006 - 2016 Xylor Baysklef, Kermitt Quirk,
+// Thraxis Epsilon, Gigs Taggart, Strife Onizuka, Huney Jewell,
+// Salahzar Stenvaag, Lulu Pink, Nandana Singh, Cleo Collins, Satomi Ahn,
+// Joy Stipe, Wendy Starfall, Romka Swallowtail, littlemousy,
+// Garvin Twine et al.
+// Licensed under the GPLv2.  See LICENSE for full details.
 
 // How to use:
-// 
+//
 // - You need a Mesh-Strip with 6 Faces next to each other. Each Face should have 1 Material.
-// - Link the Strips together next to each other. 
+// - Link the Strips together next to each other.
 // - Name them like this: MeshLabel~number~line
-//      number is the mesh-number from 0 to how many you linked horizontally   
+//      number is the mesh-number from 0 to how many you linked horizontally
 //      line is the vertical number from 0 to how many lines you have
 //
 //  Example:
@@ -69,7 +69,6 @@ string g_sFontMenu = "Font";
 string g_sColorMenu = "Color";
 
 list g_lMenuIDs;  //three strided list of avkey, dialogid, and menuname
-integer g_iMenuStride = 3;
 
 //integer TIMEOUT_READY = 30497;
 //integer TIMEOUT_REGISTER = 30498;
@@ -192,7 +191,7 @@ integer LabelsCount() {
             llSetLinkPrimitiveParamsFast(iLink,[PRIM_DESC,"Label~notexture~nocolor~nohide~noshiny"]);
         } else if (sLabel == "LabelBase") g_lLabelBaseElements += iLink;
     }
-    
+
     if (bMultiLine && llGetListLength(lSingleParamLinks) > 0) // if we have multible lines, check if all prims are correctly named
     {
         g_sErrorMsg += "Error! Some of your label prims don't have the line parameter in the name! (Should be: MeshLabel~num~line) \n";
@@ -205,7 +204,7 @@ integer LabelsCount() {
         g_sErrorMsg += "\n";
         ok = FALSE;
     }
-    
+
     if (ok) {
         integer i;
         for (i=0; i<llGetListLength(g_lLabelLinks);++i)
@@ -222,11 +221,11 @@ integer LabelsCount() {
                 integer iLine = 0;
                 if (llGetListLength(lTmp) > 2) iLine = llList2Integer(lTmp,2); // keep it compatible with old single-line version
                 integer link = -1;
-                
+
                 list lLineList = llParseString2List(llList2String(g_lLabelLinks,iLine),["|"],[]);
-                
+
                 link = llList2Integer(lLineList,iLabel);
-                if (link == 0) 
+                if (link == 0)
                 {
                     if (iLabel > llGetListLength(lLineList) -1) {
                         g_sErrorMsg += "Error! First Parameter of the label prim with the link number "+(string)iLink+" exceeds the number of prims in line "+(string)iLine+" (Current="+(string)iLabel+" Max="+(string)(llGetListLength(lLineList) -1)+")\n";
@@ -241,7 +240,7 @@ integer LabelsCount() {
                 }
             }
         }
-    } 
+    }
     if (!ok) {
         if (~llSubStringIndex(llGetObjectName(),"Installer") && ~llSubStringIndex(llGetObjectName(),"Updater"))
             return 1;
@@ -277,7 +276,7 @@ UpdateGlow(integer iLink, integer iAlpha) {
         i = llListFindList(g_lGlows,[iLink]);
         if (i != -1) llSetLinkPrimitiveParamsFast(iLink, [PRIM_GLOW, ALL_SIDES, llList2Float(g_lGlows, i+1)]);
     }
-}   
+}
 
 SetLine(integer iNumber, string sText)
 {
@@ -319,7 +318,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     key kMenuID = llGenerateKey();
     llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, iMenuType], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, iMenuType], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, iMenuType];
 }
 
@@ -339,9 +338,9 @@ MainMenu(key kID, integer iAuth) {
     {
         lButtons += [g_sTextMenu+(string)(i+1)];
     }
-    
+
     lButtons += [g_sColorMenu, g_sFontMenu, Checkbox(g_iShow, "Show")];
-    
+
     if (llGetListLength(g_lLabelLinks) < 3)  // Too much work to scroll more than 2 lines.
     {
         lButtons+=Checkbox(g_iScroll, "Scroll");
@@ -415,7 +414,7 @@ UserCommand(integer iAuth, string sStr, key kAv) {
                 else if (sValue == "off") g_iScroll = FALSE;
                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, g_sSettingToken+"scroll="+(string)g_iScroll, "");
             } else {
-                
+
                 integer iLine;
                 if (llGetSubString(sCommand,-1,-1) == "t") iLine = 0;
                 else iLine = ((integer)llGetSubString(sCommand,-1,-1));
@@ -424,7 +423,7 @@ UserCommand(integer iAuth, string sStr, key kAv) {
                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, g_sSettingToken + "text"+(string)iLine+"=" + sNewText, "");
                 if (!g_iShow)
                     llMessageLinked(LINK_SET, NOTIFY, "0"+"The label is currently disabled, it will not show up until you enable it.", kAv);
-                
+
                 if (llStringLength(sNewText) > llList2Integer(g_lCharLimit,iLine)) {
                         string sDisplayText = llGetSubString(sNewText, 0, llList2Integer(g_lCharLimit,iLine)-1);
                         llMessageLinked(LINK_SET, NOTIFY, "0"+"Unless your set your label to scroll it will be truncted at "+sDisplayText+".", kAv);
@@ -495,12 +494,12 @@ state active
             string sToken = llList2String(lParams, 0);
             string sValue = llList2String(lParams, 1);
             integer i = llSubStringIndex(sToken, "_");
-            
-            
+
+
             //integer ind = llListFindList(g_lSettingsReqs, [sToken]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
-            
+
+
             if (llGetSubString(sToken, 0, i) == g_sSettingToken) {
                 sToken = llGetSubString(sToken, i + 1, -1);
                 if (llGetSubString(sToken,0,-2) == "text") g_lLabelText = llListReplaceList(g_lLabelText,[sValue],(integer)llGetSubString(sToken,-1,-1),(integer)llGetSubString(sToken,-1,-1));
@@ -518,15 +517,15 @@ state active
                 }
             }
         }else if(iNum == LM_SETTING_EMPTY){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
+
         } else if(iNum == LM_SETTING_DELETE){
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [sStr]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-        
+
         } else if (iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
             if (!g_bHasError) llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu + "|" + g_sSubMenu, "");
             else llOwnerSay(g_sErrorMsg);
@@ -534,7 +533,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if (~iMenuIndex) {
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 list lMenuParams = llParseString2List(sStr, ["|"], []);
                 key kAv = (key)llList2String(lMenuParams, 0);
                 string sMessage = llList2String(lMenuParams, 1);
@@ -586,7 +585,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if (iNum == REBOOT && sStr == "reboot") llResetScript();
          else if(iNum == LINK_CMD_DEBUG){
             integer onlyver=0;
@@ -603,7 +602,7 @@ state active
     }
 
     timer() {
-    
+
         integer i;
         for (i=0; i<llGetListLength(g_lScrollText);++i)
         {
@@ -613,7 +612,7 @@ state active
             for(iCharPosition=0; iCharPosition < llList2Integer(g_lCharLimit,i); iCharPosition++)
                 RenderString(iCharPosition, llGetSubString(sText, iCharPosition, iCharPosition),i);
             g_lScrollPos = llListReplaceList(g_lScrollPos,[iLineScroll+1],i,i);
-            
+
             if(llList2Integer(g_lScrollPos,i) > llStringLength(llList2String(g_lScrollText,i))) g_lScrollPos = llListReplaceList(g_lScrollPos,[0],i,i);
         }
     }

--- a/src/collar/oc_particle.lsl
+++ b/src/collar/oc_particle.lsl
@@ -76,7 +76,6 @@ string Uncheckbox(string Button){
 list g_lSettings=g_lDefaultSettings;
 
 list g_lMenuIDs;
-integer g_iMenuStride = 3;
 key g_kWearer;
 
 key NULLKEY;
@@ -143,7 +142,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
     if (~iIndex)
-        g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sMenuName], iIndex, iIndex + g_iMenuStride - 1);
+        g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sMenuName], iIndex, iIndex + 2);
     else
         g_lMenuIDs += [kID, kMenuID, sMenuName];
 }
@@ -527,7 +526,7 @@ state active
                 string sButton = llList2String(lMenuParams, 1);
                 integer iAuth = (integer)llList2String(lMenuParams, 3);
                 string sMenu=llList2String(g_lMenuIDs, iMenuIndex + 1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if (sButton == UPMENU) {
                     if(sMenu == "configure") llMessageLinked(LINK_SET, iAuth, "menu " + PARENTMENU, kAv);
                     else ConfigureMenu(kAv, iAuth);
@@ -648,7 +647,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kMessageID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
         } else if (iNum == LM_SETTING_RESPONSE) {
            // Debug ("LocalSettingsResponse: " + sMessage);
             integer i = llSubStringIndex(sMessage, "=");

--- a/src/collar/oc_relay.lsl
+++ b/src/collar/oc_relay.lsl
@@ -13,13 +13,13 @@ Felkami (Caraway Ohmai)
 
 Kristen Mynx,  Phidoux (taya Maruti)
     *May 2022  - Fixed bug: !release or @clear sent to the relay would clear all
-    restrictions and exceptions from the collar.   Changed the relay to send all RLV 
+    restrictions and exceptions from the collar.   Changed the relay to send all RLV
     commands through RLV_CMD link messages instead of directly to the viewer.  oc_rlvsys
     will process them, and arbitrate between collar and relay restrictions and exceptions.
     Also removed DO_RLV_REFRESH which cleared all restrictions and exceptions.
 
    *July 2022  - Fixed bug: Ask mode only accepted one RLV command from the object.
-    
+
 et al.
 
 Licensed under the GPLv2. See LICENSE for full details.
@@ -98,7 +98,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -207,7 +207,6 @@ string tf(integer a){
 }
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -426,7 +425,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -530,7 +529,7 @@ state active
 
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);

--- a/src/collar/oc_resizer.lsl
+++ b/src/collar/oc_resizer.lsl
@@ -17,7 +17,6 @@ string g_sParentMenu = "Settings";
 //string g_sDeviceType = "collar";
 
 list g_lMenuIDs;//3-strided list of avkey, dialogid, menuname
-integer g_iMenuStride = 3;
 
 string POSMENU = "Position";
 string ROTMENU = "Rotation";
@@ -91,7 +90,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     //Debug("Made menu.");
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, sMenuType];
 }
 
@@ -266,7 +265,7 @@ state active
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
                 //remove stride from g_lMenuIDs
                 //we have to subtract from the index because the dialog id comes in the middle of the stride
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                 if (sMenuType == g_sSubMenu) {
                     if (sMessage == UPMENU) llMessageLinked(LINK_SET, iAuth, "menu " + g_sParentMenu, kAv);
                     else if (sMessage == POSMENU) PosMenu(kAv, iAuth);
@@ -332,7 +331,7 @@ state active
             if (iMenuIndex != -1) {
                 //remove stride from g_lMenuIDs
                 //we have to subtract from the index because the dialog id comes in the middle of the stride
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
             }
         }
         else if (iNum == REBOOT && sStr == "reboot") llResetScript();

--- a/src/collar/oc_rlvsuite.lsl
+++ b/src/collar/oc_rlvsuite.lsl
@@ -1,9 +1,9 @@
 /*// This file is part of OpenCollar.
-//  Copyright (c) 2018 - 2019 Tashia Redrose, Silkie Sabra, lillith xue                            
-// Licensed under the GPLv2.  See LICENSE for full details. 
+//  Copyright (c) 2018 - 2019 Tashia Redrose, Silkie Sabra, lillith xue
+// Licensed under the GPLv2.  See LICENSE for full details.
 medea (medea destiny)
     June 2021   -   Fix for issue #492 / issue #432, command to update camera settings (blur amount, maxcamera and mincamera)
-                    when numeric value changed via RLV/RLV settings/Camera used insufficent auth level and incorrect 
+                    when numeric value changed via RLV/RLV settings/Camera used insufficent auth level and incorrect
                     bitmask values to alter restriction while active even though the setting was altered.
                 -   Fix for issue #586, Dazzle set wrong restriction (was setting camunlock instead of renderresolutiondivisor)
                     Added comments explaining the restrictions settings to make life easier for future
@@ -11,12 +11,12 @@ medea (medea destiny)
     Sept 2021   -   Fixes to comments above
                 -   Corrected values for Rummage and Dress restrictions, added @emote=n to Talk restrictions #649
                 -   Restored SetDebug, SetEnv and Mouselook restrictions which had gone missing.
-                -   Added Camera settings & Muffle to restriction settings. Created shortcut to camera settings 
-                    from camera restrictions category, and support correct BACK button behavior so it returns 
+                -   Added Camera settings & Muffle to restriction settings. Created shortcut to camera settings
+                    from camera restrictions category, and support correct BACK button behavior so it returns
                     the user to whichever menu they arrived at that from #649
-                -   MENU REDESIGN. At time of writing this is still being discussed, but at this moment the 
-                    individual restrictions subcategory menus are placed below the presets, on the basis that 
-                    standard UI design principles call for detailed, multi-page functions to go lower in the 
+                -   MENU REDESIGN. At time of writing this is still being discussed, but at this moment the
+                    individual restrictions subcategory menus are placed below the presets, on the basis that
+                    standard UI design principles call for detailed, multi-page functions to go lower in the
                     attention hierarchy that quick, single-click preset functions. Various buttons/terminologies
                     have been changed to try to make the whole thing more user-friendly. Also "macro" terminology
                     has been removed, and preset used only where necessary to differentiate. issues #649 & # 654
@@ -24,23 +24,23 @@ medea (medea destiny)
                     lists of restrictions and given chat command "(prefix)restriction list". Also used by List Presets
                     button, which lists what the preset restriction buttons actually do. #649
                 -   Given extensive explanatory text in menus. ListRestrictions() function is used to print out all
-                    restrictions the wearer is currently under, rather than requiring menu user to visit every 
+                    restrictions the wearer is currently under, rather than requiring menu user to visit every
                     category menu to find out.  #649
                 -   "Daze" preset renamed to "Names/Map", "Dazzle" to "Blur", and "Rummage" to "Inventory" because
                     older names were downright confusing.  #649
                 -   Changed some names in g_lRLVlist to be clearer #649
-                -   Changed auth for adding/removing presets to CMD_OWNER AND CMD_TRUSTED to match the auth 
-                    requirements of setting individual restrictions as short-term solution to issue #656. 
+                -   Changed auth for adding/removing presets to CMD_OWNER AND CMD_TRUSTED to match the auth
+                    requirements of setting individual restrictions as short-term solution to issue #656.
                 -   Added Restore function to Customize menu to restore presets to defaults, per issue #663
                 -   Rewritten dialog code to set individual restrictions, 'cos it was badly broken. Issue #664
-    Feb 2022    -   Fix for #732: Empty g_lMacros list returned via LM_SETTING_RESPONSE parses as a list with a single 
+    Feb 2022    -   Fix for #732: Empty g_lMacros list returned via LM_SETTING_RESPONSE parses as a list with a single
                     empty element, thus messing up the list stride. Not sure why we're keeping nulls here, but setting
-                    to empty list if list length is too short works.                   
-                
-                             
-                             
-                             
-*/        
+                    to empty list if list length is too short works.
+
+
+
+
+*/
 string g_sScriptVersion = "8.2";
 
 string g_sParentMenu = "RLV";
@@ -95,7 +95,7 @@ integer RLV_ON = 6101; // send to inform plugins that RLV is enabled now, no mes
 
 integer DIALOG = -9000;
 integer DIALOG_RESPONSE = -9001;
-//integer DIALOG_TIMEOUT = -9002;
+integer DIALOG_TIMEOUT = -9002;
 
 
 
@@ -132,16 +132,16 @@ list g_lCategory = ["Chat",
 list g_lUtilityNone = ["BACK"];
 /*
  ****Understanding g_lRLVList and the restrictions mask****
-All RLV restrictions are stored as a pair of bitmasks, g_iRestrictions1 and g_iRestrictions 2. 
+All RLV restrictions are stored as a pair of bitmasks, g_iRestrictions1 and g_iRestrictions 2.
 If you look at g_lRLVList below, you will see this list forms a strided list in the format:
 Button name, Category Value, RLV Command
 The Category Value determines which subcategory of the restrictions menu the restriction will be listen in.
 0=chat, 1= show/hide, 2=teleport, 3=misc, 4=edit/mod, 5=Interact, 6=movement, 7=camera and 8=outfit
 Each restriction is given a binary value, which will be 2^index/3 -- divided by three because this is a list with a stride of 3, so each group of 3 values represents one restriction. The index used to provide the power value is listed
-in the comments beside each group of 3 entries below. For example the sendIM restriction has the number 8 next to it, and so the binary value of sendim is 2^8, or 256. 
-We can store 31 different restrictions in each of the two restrictions integers. Thus g_iRestrictions1 is the combined bitmask of all restrictions from emote (0) to rez (30). Restrictions above this value are stored in g_iRestrictions2,  starting from 2^0 (1). Thus the index is no longer 2^index/3, but 2^index/3-31. For example a list index of 93 (addattach) gives us 93/3-31 =0. 
+in the comments beside each group of 3 entries below. For example the sendIM restriction has the number 8 next to it, and so the binary value of sendim is 2^8, or 256.
+We can store 31 different restrictions in each of the two restrictions integers. Thus g_iRestrictions1 is the combined bitmask of all restrictions from emote (0) to rez (30). Restrictions above this value are stored in g_iRestrictions2,  starting from 2^0 (1). Thus the index is no longer 2^index/3, but 2^index/3-31. For example a list index of 93 (addattach) gives us 93/3-31 =0.
 The number in the comment beside the restriction line in g_lRLVList (i.e. See IM for the recim restriction we have 25 26) gives the index/3 value, and the bit that's used to store this. For calculating the integer value that represents a mask, you'd do (integer)llPow(2,bit-1); i.e. for bit 1 we get 2^0=1, for bit 2 we get 2^1=2 and so on.
-Putting it all together: 
+Putting it all together:
 Imagine we have the restrictions sendIM, See IM, Start IM and Notecard in place.
 The bit values for these are:
 Send IM  = 8
@@ -155,7 +155,7 @@ g_iRestrictions2= 2^4 = 16
 We can test if a particular restiction is set with an AND conditional.
 For example, to check if whisper restriction (Power value 4) we would do:
 if(g_iRestrictions1 & llPow(2,4))
-We can set a bit simply by adding the value of the power if not set or subtracting the value if set, or we can toggle the bit by XORing the integer with the bitmask value. NOTE that LSL uses ^ for XOR, not for powers. So 
+We can set a bit simply by adding the value of the power if not set or subtracting the value if set, or we can toggle the bit by XORing the integer with the bitmask value. NOTE that LSL uses ^ for XOR, not for powers. So
 g_iRestrictions1=g_iRestrictions1^llPow(2,5) will toggle the chatnormal restriction.
 */
 integer g_iRestrictions1 = 0;
@@ -219,14 +219,14 @@ list g_lRLVList = [   // ButtonText, CategoryIndex, RLVCMD          index | bit
     "Blur View"     , 7 , "setdebug_renderresolutiondivisor"    ,    // 55  25
     "MaxDistance"   , 7 , "setcam_avdistmax"                    ,    // 56  26
     "MinDistance"   , 7 , "setcam_avdistmin"                    ,    // 57  27
-    "Send Emote"    , 0 , "rediremote"                          ,    // 58  28 
+    "Send Emote"    , 0 , "rediremote"                          ,    // 58  28
     "Set Debug"     , 3 , "setdebug"                            ,    // 59  29
     "Environment"   , 3 , "setenv"                              ,    // 60  30
     "Mouselook"     , 7 , "camdistmax:0"                            // 61  31
 //    "Idle"          , 3 , "allowidle"                           ,  // Unofficial command Not supported in all viewers
-]; 
+];
 
-   
+
 
 integer g_iBlurAmount = 5;
 float g_fMaxCamDist = 2.0;
@@ -236,14 +236,13 @@ integer g_bForceMouselook = FALSE;
 integer g_iRLV = FALSE;
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
     key kMenuID = llGenerateKey();
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -265,7 +264,7 @@ list ListRestrictions(integer r1, integer r2)
 }
 
 Menu(key kID, integer iAuth) {
-    
+
     list lButtons =[];
     integer i;
     for(i=0;i<llGetListLength(g_lMacros);i+=3){
@@ -285,7 +284,7 @@ MenuManage(key kID, integer iAuth)
 MenuDetailed(key kID, integer iAuth){
     string sPrompt = "\n[Restriction Categories]\nSet anyRLV restrictions individually from these category menus.\n Current Restrictions:\n"+llDumpList2String(ListRestrictions(g_iRestrictions1,g_iRestrictions2),", ");
     Dialog(kID, sPrompt, g_lCategory, ["[Clear All]"]+g_lUtilityNone, 0, iAuth, "Restrictions~Restrictions");
-    
+
 }
 
 MenuCategory(key kID, integer iAuth, string sCategory)
@@ -295,13 +294,13 @@ MenuCategory(key kID, integer iAuth, string sCategory)
     if(sCategory=="Camera") lUtility=["Settings"]+lUtility;
 
     integer iCatIndex = llListFindList(g_lCategory,[sCategory]);
-    
+
     list lMenu = [];
     integer i;
-    
+
     for(i=0; i<llGetListLength(g_lRLVList); i+= 3){
         if(llList2Integer(g_lRLVList,i+1) == iCatIndex){
-            
+
             integer Flag1 = llRound(llPow(2,(i/3)));
             integer Flag2 = 0;
             if((i/3)>=31){
@@ -312,7 +311,7 @@ MenuCategory(key kID, integer iAuth, string sCategory)
                 if((g_iRestrictions1 & Flag1) || (g_iRestrictions2 & Flag2)) lMenu+= [Checkbox(TRUE, llList2String(g_lRLVList, i))];
                 else lMenu += [Checkbox(FALSE, llList2String(g_lRLVList,i))];
             }
-            
+
         }
     }
     Dialog(kID, sPrompt, lMenu,lUtility, 0, iAuth, "Restrictions~Category");
@@ -336,26 +335,26 @@ MenuDelete(key kID, integer iAuth)
 
 list bitpos (integer flag1,integer flag2){
     list ret=[0,0];
-    
+
     if(flag1>0){
         ret=llListReplaceList(ret,[llRound(llLog10(flag1)/llLog10(2))],0,0);
     }
-    
+
     if(flag2>0){
         ret = llListReplaceList(ret,[llRound(llLog10(flag2)/llLog10(2))],1,1);
     }
-    
-    
+
+
     return ret;
 }
-        
-        
+
+
 string FormatCommand(string sCommand,integer bEnable)
 {
     string sMod;
     if (bEnable) sMod = "=n";
     else sMod = "=y";
-    
+
     if (sCommand == "setdebug_renderresolutiondivisor") {
         if (bEnable) sMod = ":"+(string)g_iBlurAmount+"=force";
         else sMod = ":1=force";
@@ -372,10 +371,10 @@ string FormatCommand(string sCommand,integer bEnable)
     {
         sMod = ":38322"+sMod;
     }
-       
+
     //llOwnerSay("Restriction '"+sCommand+"' has changed, sending message");
     llMessageLinked(LINK_SET, LINK_CMD_RESTRICTIONS, sCommand+"="+(string)bEnable+"=-1","");
-    
+
     return sCommand+sMod;
 }
 
@@ -387,15 +386,15 @@ ApplyAll(integer iMask1, integer iMask2, integer iBoot)
     while (iMax1 > 0) {
         list pos = bitpos(iMax1, 0);
         integer iIndex = (llList2Integer(pos,0)*3)+2;
-        
-        
+
+
         if (iIndex > -1 && bool(iMax1 & iMask1) != bool(iMax1 & g_iRestrictions1)) {
             lResult += [FormatCommand(llList2String(g_lRLVList,iIndex), bool(iMax1 & iMask1))];
            // llSay(0, "lRLVListPart1.\npos: "+(string)pos+"\niIndex: "+(string)iIndex+"\nlResult[-1]: "+llList2String(lResult,-1));
         }
         iMax1 = iMax1 >> 1;
     }
-    
+
     while (iMax2 > 0) {
         list pos = bitpos(0,iMax2);
         integer iIndex = ((llList2Integer(pos,1)+30)*3)+2;
@@ -404,8 +403,8 @@ ApplyAll(integer iMask1, integer iMask2, integer iBoot)
           //  llSay(0, "lRLVListPart2.\npos: "+(string)pos+"\niIndex: "+(string)iIndex+"\nlResult[-1]: "+llList2String(lResult,-1));
         }
         iMax2 = iMax2 >> 1;
-        
-        
+
+
     }
     string sCommandList = llDumpList2String(lResult,",");
     lResult=[];
@@ -413,7 +412,7 @@ ApplyAll(integer iMask1, integer iMask2, integer iBoot)
     llMessageLinked(LINK_SET,RLV_CMD,sCommandList,"Macros");
     g_iRestrictions1 = iMask1;
     g_iRestrictions2 = iMask2;
-    
+
     if(!iBoot){
         llMessageLinked(LINK_SET, LM_SETTING_SAVE, "rlvsuite_masks=" + (string)g_iRestrictions1+","+(string)g_iRestrictions2, "");
     }
@@ -436,7 +435,7 @@ ApplyCommand(string sCommand, integer iAdd,key kID, integer iAuth)
     if (iActualIndex > -1) {
         integer allow=FALSE;
         if(iAuth==CMD_OWNER||iAuth==CMD_TRUSTED)allow=TRUE;
-        
+
         if (allow){
             if (!iAdd) {
                 if(iMenuIndex==0){
@@ -454,11 +453,11 @@ ApplyCommand(string sCommand, integer iAdd,key kID, integer iAuth)
                 }
                 g_iRestrictions1 -= iMenuIndex;
                 g_iRestrictions2 -= iMenuIndex2;
-                
+
                 llMessageLinked(LINK_SET,RLV_CMD,FormatCommand(llList2String(g_lRLVList,iActualIndex+2),FALSE),"Macros");
                 if (kID != NULL_KEY) llOwnerSay(llList2String(g_lCategory, llList2Integer(g_lRLVList,iActualIndex+1))+" - "+llList2String(g_lRLVList,iActualIndex)+" is not restricted anymore!");
             } else {
-                
+
                 if(iMenuIndex==0){
                     if((g_iRestrictions2 & iMenuIndex2)){
                         // STOP
@@ -474,7 +473,7 @@ ApplyCommand(string sCommand, integer iAdd,key kID, integer iAuth)
                 }
                 g_iRestrictions1 += iMenuIndex;
                 g_iRestrictions2 += iMenuIndex2;
-                
+
                 llMessageLinked(LINK_SET,RLV_CMD,FormatCommand(llList2String(g_lRLVList,iActualIndex+2),TRUE),"Macros");
                 if (kID != NULL_KEY) llOwnerSay(llList2String(g_lCategory, llList2Integer(g_lRLVList,iActualIndex+1))+" - "+llList2String(g_lRLVList,iActualIndex)+" is now restricted!");
             }
@@ -486,7 +485,7 @@ ApplyCommand(string sCommand, integer iAdd,key kID, integer iAuth)
 
 UserCommand(integer iNum, string sStr, key kID) {
     if (iNum<CMD_OWNER || iNum>CMD_EVERYONE) return;
-    
+
     if (llToLower(sStr)=="restrictions" || llToLower(sStr) == "menu restrictions") Menu(kID, iNum);
     else if(llToLower(sStr)=="advanced" || llToLower(sStr) == "menu [advanced]")MenuDetailed(kID, iNum);
     else if(llToLower(sStr)=="customize" || llToLower(sStr) == "menu customize") MenuManage(kID,iNum);
@@ -504,7 +503,7 @@ UserCommand(integer iNum, string sStr, key kID) {
         if(~llListFindList(g_lCategory,[sStr])) MenuCategory(kID,iNum,sStr);
     }
     if (llSubStringIndex(sStr,"preset") && llSubStringIndex(sStr,"restriction") && llSubStringIndex(sStr,"restrictions") && llSubStringIndex(sStr,"sit")) return;
-    else { 
+    else {
         string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
         string sChangekey = llList2String(llParseString2List(sStr, [" "], []),1);
         string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),2);
@@ -525,7 +524,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                         llMessageLinked(LINK_SET, NOTIFY, "0"+"Restriction presets cleared '"+sChangevalue+"'", kID);
                         ApplyAll(g_iRestrictions1 ^ (g_iRestrictions1 & llList2Integer(g_lMacros,iIndex+1)),g_iRestrictions2 ^ (g_iRestrictions2 & llList2Integer(g_lMacros,iIndex+2)),FALSE);
                         llOwnerSay("Restriction preset '"+llList2String(g_lMacros,iIndex)+"' has been cleared!");
-                    } 
+                    }
                 } else llMessageLinked(LINK_SET, NOTIFY, "0"+"Insufficient authority to set restrictions!", kID);
             } else llInstantMessage(kID,"Restriction preset '"+sChangevalue+"' does not exist!");
         } else if (sChangetype == "restriction" || sChangetype == "rlv") {
@@ -585,9 +584,9 @@ state active
         g_iRLV = FALSE;
         //llSetTimerEvent(1);
 
-        
+
     }
-    
+
     on_rez(integer iRez){
         //g_iJustRezzed=TRUE;
         // Restrictions are likely not applied at the moment, reinit the variables
@@ -595,40 +594,40 @@ state active
         llResetScript();
         //llSetTimerEvent(1);
     }
-    
+
     timer(){
         if(llGetTime()>=20 && g_iJustRezzed){
             llMessageLinked(LINK_SET, RLV_REFRESH, "",""); // refreshes rlvsuite restrictions
         }
-        
+
         //llSetText("rlvsuite\n\n=> Free Memory: "+(string)llGetFreeMemory()+"\nProfiler Max used: "+(string)llGetSPMaxMemory()+"\nUsed Memory: "+(string)llGetUsedMemory()+"\nTotal Mem: "+(string)llGetMemoryLimit()+"\n \n \n \n \n \n \n \n \n", <0,1,0>,1);
     }
-        
+
     link_message(integer iSender,integer iNum,string sStr,key kID){
        // llOwnerSay(llDumpList2String([iSender, iNum, llGetSPMaxMemory(), llGetFreeMemory()], " ^ "));
         // llOwnerSay("inum="+(string)iNum+" | kID="+(string)kID+"| sStr="+sStr);
         if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) UserCommand(iNum, sStr, kID);
         else if(iNum == MENUNAME_REQUEST) {
             if(sStr == g_sParentMenu){
-                
-                
+
+
                 llMessageLinked(LINK_SET, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");  // Register menu "Restrictions"
             }
         } else if(iNum == DIALOG_RESPONSE){
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
-                
+
                 //llOwnerSay("Memory Free: "+(string)llGetFreeMemory());
                 //llOwnerSay("Memory Used: "+(string)llGetUsedMemory());
-                
-                
-                if(sMenu == "Restrictions~Main"){ 
+
+
+                if(sMenu == "Restrictions~Main"){
                     if(sMsg == "BACK") llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     else if (sMsg == "[CUSTOMIZE]") MenuManage(kAv,iAuth);
                     else if(sMsg == "[ADVANCED]") MenuDetailed(kAv,iAuth);
@@ -638,7 +637,7 @@ state active
                     } else {
                         integer iChkbxState = CheckboxState(sMsg);
                         string sChkbxLbl = CheckboxText(sMsg);
-                        
+
                         if(!iChkbxState){
                             // toggle the macro
                             UserCommand(iAuth, "preset add "+sChkbxLbl, kAv);
@@ -672,7 +671,7 @@ state active
                            g_lMacros = ["Hear", 4, 0, "Talk" , 3, 0, "Touch", 0, 16384, "Stray", 29360128, 524288, "Inventory", 1342179328, 96, "Dress", 0, 30, "IM", 384, 0, "Names/Map", 323584, 0, "Blur", 0, 33554432];
                             llMessageLinked(LINK_SET, LM_SETTING_SAVE, "rlvsuite_macros=" + llDumpList2String(g_lMacros,"^"), "");
                         }
-                    }MenuManage(kAv,iAuth);    
+                    }MenuManage(kAv,iAuth);
                 } else if (sMenu == "Restrictions~Restrictions"){
                     if(sMsg == "BACK") Menu(kAv,iAuth);
                     else if (sMsg == "[Clear All]") {
@@ -685,19 +684,19 @@ state active
                         }
                     }
                     else MenuCategory(kAv, iAuth, sMsg);
-                
-                } 
+
+                }
                 else if (sMenu == "Restrictions~Category")
                 {
                     if(sMsg == "BACK") MenuDetailed(kAv,iAuth);
                     else if(sMsg == "Settings") llMessageLinked(LINK_SET,iAuth,"menu managecamera2",kAv);
-                    else 
+                    else
                     {
                         integer iVal=CheckboxState(sMsg);
                         sMsg = llGetSubString( sMsg, llStringLength(llList2String(g_lCheckboxes,0))+1, -1);
-                        if(llListFindList(g_lRLVList,[sMsg])>-1) 
+                        if(llListFindList(g_lRLVList,[sMsg])>-1)
                         {
-                            if(iVal) 
+                            if(iVal)
                             {
                                 if (iAuth != CMD_WEARER) ApplyCommand(sMsg,FALSE,kAv, iAuth);
                                 else llMessageLinked(LINK_SET, NOTIFY, "0%NOACCESS%", kAv);
@@ -747,15 +746,19 @@ state active
                     }
                 }
             }
+        } else if (iNum == DIALOG_TIMEOUT) {
+            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
+            if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
+                //remove stride from g_lMenuIDs
         } else if(iNum == -99999){
             if(sStr == "update_active")llResetScript();
         } else if (iNum == LM_SETTING_RESPONSE) {
             list lParams = llParseString2List(sStr, ["="], []);
-            
+
             //integer ind = llListFindList(g_lSettingsReqs, [llList2String(lParams,0)]);
             //if(ind!=-1)g_lSettingsReqs = llDeleteSubList(g_lSettingsReqs, ind,ind);
-            
-            
+
+
             if (llList2String(lParams, 0) == "rlvsuite_masks") {
                 list lMasks = llParseString2List(llList2String(lParams, 1),[","],[]);
                 if (g_iRLV) { // bad timing, RLV_ON was already called
@@ -770,7 +773,7 @@ state active
                 }
             } else if (llList2String(lParams, 0) == "rlvsuite_macros") {
                 g_lMacros = llParseStringKeepNulls(llList2String(lParams, 1), ["^"],[]);
-                if(llGetListLength(g_lMacros)<3) g_lMacros=[];  
+                if(llGetListLength(g_lMacros)<3) g_lMacros=[];
             }
             else if(llList2String(lParams,0) == "global_checkboxes") g_lCheckboxes = llCSV2List(llList2String(lParams,1));
         } else if (iNum == CMD_SAFEWORD || iNum == RLV_CLEAR || iNum == RLV_OFF){
@@ -790,7 +793,7 @@ state active
             if(sStr == "ver")onlyver=1;
             llInstantMessage(kID, llGetScriptName() +" SCRIPT VERSION: "+g_sScriptVersion);
             if(onlyver)return; // basically this command was: <prefix> versions
-            
+
             llInstantMessage(kID, llGetScriptName() +" MEMORY USED: "+(string)llGetUsedMemory());
             llInstantMessage(kID, llGetScriptName() +" MEMORY FREE: "+(string)llGetFreeMemory());
             //Commenting this out for general release 'cos memory is tight.
@@ -810,14 +813,14 @@ state active
                 if (bWasTrue) ApplyCommand("MaxDistance",FALSE, NULL_KEY, 500);
                 g_fMaxCamDist = llList2Float(lCMD,1);
                 if (bWasTrue) ApplyCommand("MaxDistance",TRUE, NULL_KEY, 500);
-            } else if (llList2String(lCMD,0) == "MinCamDist") { 
+            } else if (llList2String(lCMD,0) == "MinCamDist") {
                 integer bWasTrue = g_iRestrictions2 & (integer)(llPow(2,27));
                 if (bWasTrue) ApplyCommand("MinDistance",FALSE, NULL_KEY, 500);
                 g_fMinCamDist = llList2Float(lCMD,1);
                 if (bWasTrue) ApplyCommand("MinDistance",TRUE, NULL_KEY, 500);
             }
-        
+
         }
     }
-    
+
 }

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -138,7 +138,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -281,7 +281,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 integer g_iRebootConfirmed=FALSE;
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 //integer g_iLocked=FALSE;
 
 key g_kSettingsRead;
@@ -521,7 +520,7 @@ default
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -549,7 +548,7 @@ default
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == TIMEOUT_FIRED){
             if(sStr == "check_weld")CheckForAndSaveWeld();
         } else if(iNum == LM_SETTING_DELETE){

--- a/src/collar/oc_states.lsl
+++ b/src/collar/oc_states.lsl
@@ -9,11 +9,11 @@ Aria (Tashia Redrose)
                                 *Repurpose oc_states to be anti-crash and a interactive settings editor.
 Medea (Medea Destiny)
     *July 2021          -       *See issue #587: Added warning when script resets folders script that user should consider cleaning
-                                up their #RLV 
-    Sept 2021           -       Tighten timings and number of passes on reboot process and reduced sleep padding.                               
-                                            
-    
-    
+                                up their #RLV
+    Sept 2021           -       Tighten timings and number of passes on reboot process and reduced sleep padding.
+
+
+
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -70,7 +70,7 @@ SettingsMenu(integer stridePos, key kAv, integer iAuth)
         integer end = llGetListLength(g_lSettings);
         for(i=0;i<end;i+=3){
             if(llListFindList(lBtns,[llList2String(g_lSettings,i)])==-1)lBtns+=llList2String(g_lSettings,i);
-        }            
+        }
         sText+="\nCurrently viewing Tokens";
     } else if(stridePos==1){
         integer i=0;
@@ -102,10 +102,10 @@ SettingsMenu(integer stridePos, key kAv, integer iAuth)
         sText += "\n\nPlease enter the variable name for '"+g_sTokenView;
         lBtns=[];
     }
-    
+
     g_iLastStride=stridePos;
     Dialog(kAv, sText,lBtns, setor((lBtns!=[]), ["+ NEW", UPMENU], []), 0, iAuth, "settings~edit~"+(string)stridePos);
-    
+
 }
 
 list setor(integer test, list a, list b){
@@ -144,14 +144,13 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 list g_lSettings;
 integer g_iLoading;
 //key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 //list g_lOwner;
 //list g_lTrust;
 key g_kMenuUser;
@@ -178,7 +177,7 @@ default
     state_entry()
     {
         if(llGetStartParameter() != 0) state inUpdate;
-        
+
         g_lAlive=[];
         g_iPasses=-1;
         g_iExpectAlive=1;
@@ -187,14 +186,14 @@ default
         if(g_iVerbosityLevel>=1)
             llOwnerSay("Collar is preparing to start up, please be patient.");
     }
-    
-    
+
+
     on_rez(integer iRez){
         llResetScript();
     }
-    
+
     timer(){
-        
+
         if(g_iExpectAlive){
             if(llGetTime()>=3 && g_iPasses<2){ //>=5
                 llMessageLinked(LINK_SET,READY, "","");
@@ -209,16 +208,16 @@ default
                 g_lAlive=[];
                 g_iPasses=0;
                 llSleep(1); //10
-                
+
                 if(g_iVerbosityLevel >=1)
                     llMessageLinked(LINK_SET,NOTIFY,"0Startup in progress... be patient", llGetOwner());
                 //llMessageLinked(LINK_SET,LM_SETTING_REQUEST,"ALL","");
                 llMessageLinked(LINK_SET,0,"initialize","");
             }
-            
+
             return;
         }
-        
+
         if(!g_iWaitMenu && llGetListLength(g_lTimers) == 0)
             llSetTimerEvent(15);
         // Check all script states, then check list of managed scripts
@@ -234,20 +233,20 @@ default
                 llSetScriptState(scriptName,TRUE);
                 llSleep(1);
                 iModified=TRUE;
-                if(scriptName=="oc_folders") llOwnerSay("WARNING! Opencollar detected that your folder script stopped running, and has restarted it. Usually this is a stack heap error, which means the folder script ran out of memory trying to read your folders. This happens when you have too many subfolders in one place. To stop this happening, please consider reorganizing your #RLV so that no individual folder has too many subfolders inside it, and check for folders that begin with a ~ directly in your #RLV root folder that can be deleted -- normally these are temporary attachment folders and are no longer needed."); 
+                if(scriptName=="oc_folders") llOwnerSay("WARNING! Opencollar detected that your folder script stopped running, and has restarted it. Usually this is a stack heap error, which means the folder script ran out of memory trying to read your folders. This happens when you have too many subfolders in one place. To stop this happening, please consider reorganizing your #RLV so that no individual folder has too many subfolders inside it, and check for folders that begin with a ~ directly in your #RLV root folder that can be deleted -- normally these are temporary attachment folders and are no longer needed.");
                 if(g_iVerbosityLevel >=1)
                     llMessageLinked(LINK_SET, NOTIFY, "0"+scriptName+" has been reset. If the script stack heaped, please file a bug report on our github.", llGetOwner());
             }
         }
-        
+
         if(iModified) llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "ALL","");
-        
+
         if(!g_iLoading && g_iWaitMenu){
             g_iWaitMenu=FALSE;
             SettingsMenu(0,g_kMenuUser,g_iLastAuth);
         }
-        
-        
+
+
         // proceed
         i=0;
         end = llGetListLength(g_lTimers);
@@ -257,22 +256,22 @@ default
             integer diff = llList2Integer(g_lTimers,i+2);
             if((now-start)>=diff){
                 string signal = llList2String(g_lTimers,i);
-                
+
                 g_lTimers = llDeleteSubList(g_lTimers, i,i+2);
                 i=0;
                 end=llGetListLength(g_lTimers);
                 llMessageLinked(LINK_SET, TIMEOUT_FIRED, signal, "");
-                
+
             }
         }
-        
+
         //llWhisper(0, "oc_states max used over time: "+(string)llGetSPMaxMemory());
     }
-    
-    
+
+
     link_message(integer iSender, integer iNum, string sStr, key kID){
         if(iNum == REBOOT && sStr == "reboot --f")llResetScript();
-        
+
         if(iNum>=CMD_OWNER && iNum <= CMD_EVERYONE){
             if(sStr == "fix"){
                 g_iExpectAlive=1;
@@ -281,7 +280,7 @@ default
                 g_lAlive=[];
                 g_iLoading=FALSE;
                 g_lSettings=[];
-                
+
                 llMessageLinked(LINK_SET, LM_SETTING_REQUEST, "ALL", "");
             }
             if(llToLower(sStr)=="settings edit"){
@@ -302,13 +301,13 @@ default
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
                 integer iRemenu=FALSE;
-                
+
                 if(sMenu == "Menu~Main"){
                     if(sMsg == UPMENU){
                         iRemenu=FALSE;
@@ -337,10 +336,10 @@ default
                         SettingsMenu(9, kAv, iAuth);
                         return;
                     }
-                    
+
                     g_sVariableView=sMsg;
                     SettingsMenu(2, kAv,iAuth);
-                    
+
                 } else if(sMenu == "settings~edit~2"){
                     if(sMsg == UPMENU){
                         SettingsMenu(1,kAv,iAuth);
@@ -383,15 +382,15 @@ default
                 } else if(sMenu == "settings~edit~9"){
                     g_sVariableView=sMsg;
                     g_lSettings += [g_sTokenView,g_sVariableView,"not set"];
-                    
+
                     SettingsMenu(3, kAv,iAuth);
                 }
-                        
+
             }
-            
+
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         }else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);
@@ -403,15 +402,15 @@ default
                     g_iVerbosityLevel = (integer)sVal;
                 }
             }
-            
-            
+
+
             if(sStr == "settings=sent"){
                 g_iLoading=FALSE;
                 return;
             }
-            
+
             if(g_iLoading && llListFindList(g_lSettings, [sToken, sVar, sVal]) == -1 )g_lSettings+=[sToken, sVar, sVal];
-            
+
         } else if(iNum == 0){
             if(sStr == "initialize"){
                 llMessageLinked(LINK_SET, TIMEOUT_READY, "","");
@@ -425,7 +424,7 @@ default
                 g_lAlive+=[sStr];
             }else return;
             llResetTime();
-            llSetTimerEvent(1);            
+            llSetTimerEvent(1);
         }
     }
 }

--- a/src/collar/oc_themes.lsl
+++ b/src/collar/oc_themes.lsl
@@ -64,7 +64,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -241,7 +241,6 @@ ThemeSelect(key kAv, integer iAuth){
 }
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -531,7 +530,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -572,7 +571,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);

--- a/src/collar/oc_titler.lsl
+++ b/src/collar/oc_titler.lsl
@@ -6,7 +6,7 @@ Aria (Tashia Redrose)
     * Mar 2020      - Fix bug where title would not detect the float text prim.
                     - Fixed bug where titler would display garbled text as a result of failing to decode base64
     * Jan 2020      - Rewrote titler to cleanup the code and make easier to read
-    
+
 Medea (Medea Destiny)
     Oct 2021    -   Refactored SAVE to only save changed settings. Added helpful menu text.
                     Added text2col() function that makes a sensible colour vector out of whatever
@@ -92,7 +92,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -121,7 +121,7 @@ integer validvector(string input)
         }
     return TRUE;
 }
-        
+
 vector text2col(string input)
 {
     list t=llParseString2List(input,[",","<",">"," "],[]);
@@ -140,7 +140,7 @@ vector text2col(string input)
     if(norm) out=out/255;
     return out;
 }
-        
+
 
 UserCommand(integer iNum, string sStr, key kID) {
     if (iNum<CMD_OWNER || iNum>CMD_WEARER) return;
@@ -251,7 +251,6 @@ integer g_iOffset=8;
 vector g_vColor = <1,1,1>;
 string g_sTitle;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -340,7 +339,7 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
@@ -416,7 +415,7 @@ state active
             }
         }else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);

--- a/src/cuffs/oc_cuff.lsl
+++ b/src/cuffs/oc_cuff.lsl
@@ -14,7 +14,7 @@ Ping (Pingout Duffield)
 Kristen Mynx
     * May 2022        -       Added resizer support
 Kristen Mynx
-    * July 2022       -       Fix "BACK" buttons on resizer 
+    * July 2022       -       Fix "BACK" buttons on resizer
 Ping (Pingout Duffield)
     * Nov 2022        -       Add in link message for cuff [New Theme] button using iNum == 32
 et al.
@@ -117,7 +117,7 @@ integer REPLY_POINT_KEY = -58933;
 integer CLEAR_ALL_CHAINS = -58934;
 integer STOP_CUFF_POSE = -58935; // <-- stops all active animations originating from this cuff
 integer DESUMMON_PARTICLES = -58936; // Message only includes the From point name
-integer CLEAR_POSE_RESTRICTION = -58937;  // Clear Restrictions between poses 
+integer CLEAR_POSE_RESTRICTION = -58937;  // Clear Restrictions between poses
 
 integer g_iFirstInit=TRUE;
 
@@ -133,7 +133,6 @@ list g_lPoses = [];
 
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 string UPMENU = "BACK";
 
@@ -143,7 +142,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llRegionSayTo(g_kCollar, API_CHANNEL, llList2Json(JSON_OBJECT, [ "pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID ]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -178,7 +177,7 @@ Menu(key kID, integer iAuth) {
      && (llGetObjectPermMask(MASK_OWNER) & (PERM_COPY | PERM_MODIFY | PERM_TRANSFER))  == (PERM_COPY | PERM_MODIFY | PERM_TRANSFER)){
         if(!g_iHidden)
             lButtons+=["New Theme"];
-        }        
+        }
     }
     if(llGetInventoryType("oc_cuff_resizer")==INVENTORY_SCRIPT){
         if(!g_iHidden)
@@ -715,7 +714,7 @@ default
                     }
                     else if (iNum == DIALOG_TIMEOUT) {
                         integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 3);  //remove stride from g_lMenuIDs
+                        f (~iMenuIndex1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
                     }
                     else if (iNum == DIALOG_RESPONSE) {
                         integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
@@ -755,7 +754,7 @@ default
                                 }else if(sMsg == "ClearChains"){
                                     if(iAuth==CMD_OWNER)
                                         Link("from_addon", CLEAR_ALL_CHAINS, "", "");
-                                } 
+                                }
                                 else if(sMsg == Checkbox(g_iCuffLocked, "Lock")){
                                     if(iAuth==CMD_OWNER){
                                         g_iCuffLocked=1-g_iCuffLocked;
@@ -885,7 +884,7 @@ default
             key kLMKey = (key)llGetSubString(msg,0,35);
             list lLMCmd = llParseString2List(msg,["|"],[]);
             if (kLMKey == llGetOwner()) {
-                if (llGetListLength(lLMCmd) > 1) {  
+                if (llGetListLength(lLMCmd) > 1) {
                 // A Lockmeister command
                     string sLMCMD = llList2String(lLMCmd,2);
                     string sLMPoint = llList2String(lLMCmd,3);
@@ -895,12 +894,12 @@ default
                         integer iMapIndex = llListFindList(g_lLMV2Map, [sLMPoint]);
                         if (iMapIndex > -1) {
                             lKey = GetKey(llList2String(g_lLMV2Map, iMapIndex + 1));
-                            if (llList2Integer(lKey, 0) != LINK_ROOT) 
-                            llRegionSayTo(id, -8888,(string)llGetOwner()+"|LMV2|ReplyPoint|"+sLMPoint+"|"+llList2String(lKey, 1)); 
+                            if (llList2Integer(lKey, 0) != LINK_ROOT)
+                            llRegionSayTo(id, -8888,(string)llGetOwner()+"|LMV2|ReplyPoint|"+sLMPoint+"|"+llList2String(lKey, 1));
                         }
                     }
-                } 
-                else { 
+                }
+                else {
                 // A Lockmeister Ping
                     string sLMPoint = llGetSubString(msg,36,-1);
                     if (llListFindList(g_lLMV2Map, [sLMPoint]) > -1) {

--- a/src/cuffs/oc_cuff.lsl
+++ b/src/cuffs/oc_cuff.lsl
@@ -714,13 +714,13 @@ default
                     }
                     else if (iNum == DIALOG_TIMEOUT) {
                         integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                        f (~iMenuIndex1) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
+                        f (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
                     }
                     else if (iNum == DIALOG_RESPONSE) {
                         integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
                         if (iMenuIndex != -1) {
                             string sMenu = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                             list lMenuParams = llParseString2List(sStr, ["|"], []);
                             key kAv = llList2Key(lMenuParams, 0);
                             string sMsg = llList2String(lMenuParams, 1);

--- a/src/cuffs/oc_cuff_resizer.lsl
+++ b/src/cuffs/oc_cuff_resizer.lsl
@@ -23,7 +23,6 @@ string g_sParentMenu = "Cuff Resize";
 integer API_CHANNEL = 0x60b97b5e;
 
 list g_lMenuIDs;//3-strided list of avkey, dialogid, menuname
-integer g_iMenuStride = 3;
 
 string POSMENU = "Position";
 string ROTMENU = "Rotation";
@@ -98,7 +97,7 @@ Dialog(key kRCPT, string sPrompt, list lChoices, list lUtilityButtons, integer i
     llMessageLinked(LINK_SET, DIALOG, (string)kRCPT + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
     //Debug("Made menu.");
     integer iIndex = llListFindList(g_lMenuIDs, [kRCPT]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kRCPT, kMenuID, sMenuType], iIndex, iIndex + 2);
     else g_lMenuIDs += [kRCPT, kMenuID, sMenuType];
 }
 */
@@ -108,7 +107,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llRegionSayTo(g_kCollar,API_CHANNEL, llList2Json(JSON_OBJECT, [ "pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID ]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -270,7 +269,7 @@ default
                     string sStr  = llJsonGetValue(msg, ["sMsg"]);
                     key kID      = (key) llJsonGetValue(msg, ["kID"]);
 
-                    
+
 //------------
 
         if (iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
@@ -288,7 +287,7 @@ default
                 string sMenuType = llList2String(g_lMenuIDs, iMenuIndex + 1);
                 //remove stride from g_lMenuIDs
                 //we have to subtract from the index because the dialog id comes in the middle of the stride
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 1);
                 if (sMenuType == g_sSubMenu) {
                     if (sMessage == UPMENU) llMessageLinked(LINK_SET, 33, (string)kAv, (key)((string)iAuth));
                     else if (sMessage == POSMENU) PosMenu(kAv, iAuth);
@@ -354,7 +353,7 @@ default
             if (iMenuIndex != -1) {
                 //remove stride from g_lMenuIDs
                 //we have to subtract from the index because the dialog id comes in the middle of the stride
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 1);
             }
         }
         else if (iNum == REBOOT && sStr == "reboot") llResetScript();
@@ -370,9 +369,9 @@ default
 
 
 //------------
-                    
+
                 }
-            }                                
+            }
         }
     }
     link_message(integer iSender, integer iNum, string sStr, key kID) {

--- a/src/cuffs/oc_cuff_themes.lsl
+++ b/src/cuffs/oc_cuff_themes.lsl
@@ -5,18 +5,18 @@ Copyright ©2021
 Aria (Tashia Redrose)
     * Oct 2020       -       Created oc_themes
 Kristen Mynx
-    * May 2022       -       Modify to oc_cuff_themes    
+    * May 2022       -       Modify to oc_cuff_themes
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
 */
 
 integer API_CHANNEL = 0x60b97b5e;
-string g_sParentMenu = "Apps";
-string g_sSubMenu = "Themes";
+//string g_sParentMenu = "Apps";
+//string g_sSubMenu = "Themes";
 
 
-integer g_iHide;
+//integer g_iHide;
 
 //MESSAGE MAP
 //integer CMD_ZERO = 0;
@@ -170,11 +170,11 @@ ScanThemes(){
 }
 
 key g_kWearer;
-list g_lMenuIDs;
-integer g_iMenuStride;
-list g_lOwner;
-list g_lTrust;
-list g_lBlock;
+//list g_lMenuIDs;
+//integer g_iMenuStride;
+//list g_lOwner;
+//list g_lTrust;
+// list g_lBlock;
 integer g_iLocked=FALSE;
 string sBuffer = "";
 E(key kID, string sMsg){
@@ -257,7 +257,7 @@ default
         // so we can evesdrop on messages from the collar
         // specifically -9001 where a string matches a notecard ending in .theme
         API_CHANNEL = ((integer)("0x" + llGetSubString((string)llGetOwner(), 0, 8))) + 0xf6eb - 0xd2;
-        llListen(API_CHANNEL, "", "", "");        
+        llListen(API_CHANNEL, "", "", "");
     }
 
     changed(integer iChange){

--- a/src/devtest/MenuTester.lsl
+++ b/src/devtest/MenuTester.lsl
@@ -1,4 +1,4 @@
-  
+
 /*
 This file is a part of OpenCollar.
 Copyright ©2020
@@ -8,8 +8,8 @@ Copyright ©2020
 Aria (Tashia Redrose)
     * Nov 2020      - Add a sorted labels option, fix license on menu tester to GPLv2
     * Sep 2020      - Basic menu tester script to test all functions of the oc_dialog script
-    
-    
+
+
 et al.
 
 Licensed under the GPLv2. See LICENSE for full details.
@@ -63,7 +63,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth + "|"+(string)iSort, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -80,7 +80,7 @@ LongTester(key kID, integer iAuth){
     for(i=0;i<end;i++){
         lButtons += llMD5String((string)i, 0);
     }
-    
+
     Dialog(kID, sPrompt, lButtons, [UPMENU], 0, iAuth, "Menu~LongText",0);
 }
 
@@ -122,7 +122,7 @@ UserCommand(integer iNum, string sStr, key kID) {
     if (llToLower(sStr)==llToLower(g_sSubMenu) || llToLower(sStr) == "menu "+llToLower(g_sSubMenu)) Menu(kID, iNum);
     //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else {
-        integer iWSuccess = 0; 
+        integer iWSuccess = 0;
         string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
         string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         string sText;
@@ -132,7 +132,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -181,17 +180,17 @@ state active
         }
         string sAppend;
         if(g_iSorted)sAppend="Sort";
-        
+
         Dialog(g_kTmpScan, "\n[Object ID Test]", lIDS, [UPMENU],0,g_iTmpAuth, "Menu~Objs"+sAppend,g_iSorted);
     }
-    
+
     no_sensor(){
         string sAppend="";
         if(g_iSorted)sAppend="Sort";
         Dialog(g_kTmpScan, "\n[Object ID Test]\n\nNothing found", [], [UPMENU], 0, g_iTmpAuth, "Menu~Objs", g_iSorted);
     }
-    
-    
+
+
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) UserCommand(iNum, sStr, kID);
         else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
@@ -200,12 +199,12 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
-                
+
                 if(sMenu == "Menu~Main"){
                     if(sMsg == UPMENU) llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     else if(sMsg == "LongText"){
@@ -228,8 +227,8 @@ state active
                     } else {
                         llSay(0, "You selected: "+sMsg);
                     }
-                    
-                    
+
+
                     LongTester(kAv,iAuth);
                 } else if(sMenu == "Menu~Avs"){
                     if(sMsg == UPMENU){
@@ -246,7 +245,7 @@ state active
                     }else{
                         llSay(0, "You selected: "+sMsg);
                     }
-                    
+
                     ObjsTester(kAv,iAuth);
                 }else if(sMenu == "Menu~Colors"){
                     if(sMsg == UPMENU){
@@ -255,7 +254,7 @@ state active
                     }else{
                         llSay(0, "You selected: "+sMsg);
                     }
-                    
+
                     Colors(kAv,iAuth);
                 } else if(sMenu == "Menu~ObjsSort"){
                     if(sMsg == UPMENU){
@@ -264,7 +263,7 @@ state active
                     } else {
                         llSay(0, "You selected: "+sMsg);
                     }
-                    
+
                     ObjsSortTester(kAv,iAuth);
                 } else if(sMenu == "Menu~SortedText"){
                     if(sMsg == UPMENU){
@@ -273,13 +272,13 @@ state active
                     } else {
                         llSay(0, "You selected: "+sMsg);
                     }
-                    
+
                     SortedText(kAv, iAuth);
                 }
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         }
         //llOwnerSay(llDumpList2String([iSender,iNum,sStr,kID],"^"));
     }

--- a/src/remote/oc_remote_menus.lsl
+++ b/src/remote/oc_remote_menus.lsl
@@ -1,4 +1,4 @@
-  
+
 /*
 This file is a part of OpenCollar.
 Copyright ©2020
@@ -8,8 +8,8 @@ Copyright ©2020
 
 Aria (Tashia Redrose)
     * December 2020       -       Recreated oc_Remote
-    
-    
+
+
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -17,17 +17,16 @@ https://github.com/OpenCollarTeam/OpenCollar
 */
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 string UPMENU="BACK";
 Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
     key kMenuID = llGenerateKey();
-    
+
     LM("from_addon", DIALOG, (string)kID+"|"+sPrompt+"|"+(string)iPage+"|"+llDumpList2String(lChoices, "`")+"|"+llDumpList2String(lUtilityButtons, "`")+"|"+(string)iAuth, kMenuID);
     //llRegionSayTo(g_kCollar,llList2Integer(g_lAPIListeners,0), llList2Json(JSON_OBJECT, ["pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 Menu(key kID, integer iAuth){
@@ -37,7 +36,7 @@ Menu(key kID, integer iAuth){
 AMenu(key kID, integer iAuth) {
     string sPrompt = "\n[OpenCollar Remote]\n\nRows: "+(string)g_iRows;
     list lButtons = ["+ Favorite", "- Favorite", "Buttons", "+ Rows", "- Rows"];
-    
+
     //llSay(0, "opening menu");
     Dialog(kID, sPrompt, lButtons, ["DISCONNECT", UPMENU], 0, iAuth, "Menu~Main");
 }
@@ -85,11 +84,11 @@ UserCommand(integer iNum, string sStr, key kID) {
     if (llToLower(sStr)==llToLower(g_sAddon) || llToLower(sStr) == "menu "+llToLower(g_sAddon)) Menu(kID, iNum);
     //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else {
-        //integer iWSuccess = 0; 
+        //integer iWSuccess = 0;
         string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
         //string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         //string sText;
-        
+
         if(sChangetype == "remote")
         {
             Menu(kID, iNum);
@@ -109,14 +108,14 @@ MenuButtons(key kID, integer iAuth, integer iPage)
 {
     string prompt = "[OpenCollar Remote]\n=Button Manager=\n\nButtons: "+(string)g_iBitMask;
     list buttons = [];
-    
+
     integer i=0;
     integer end = llGetListLength(g_lBTNS);
     for(i=0;i<end;i+=3)
     {
         buttons += Checkbox(llList2String(g_lBTNS, i), (integer)(g_iBitMask&(integer)llList2String(g_lBTNS,i+2)));
     }
-    
+
     Dialog(kID, prompt, buttons, ["APPLY", UPMENU], iPage, iAuth, "Menu~Buttons");
 }
 
@@ -135,18 +134,18 @@ default
         //llSay(0, llDumpList2String([iSender,iNums, sMsg, kIDx], "~"));
         if(iNums==0)
         {
-            
+
             integer iNum = (integer)llJsonGetValue(sMsg,["iNum"]);
             string sStr = llJsonGetValue(sMsg,["sMsg"]);
             key kID = (key)llJsonGetValue(sMsg,["kID"]);
-                
-                
+
+
             if(iNum == LM_SETTING_RESPONSE){
                 list lPar = llParseString2List(sStr, ["_","="],[]);
                 string sToken = llList2String(lPar,0);
                 string sVar = llList2String(lPar,1);
                 string sVal = llList2String(lPar,2);
-                    
+
                 /*if(sToken == "auth"){
                     if(sVar == "owner"){
                         //llSay(0, "owner values is: "+sVal);
@@ -159,10 +158,10 @@ default
                 }
             } else if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE){
                 UserCommand(iNum, sStr, kID);
-                
+
             } else if (iNum == DIALOG_TIMEOUT) {
                 integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+                if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
             } else if(iNum == AUTH_REPLY){
                 list lTmp = llParseString2List(sStr, ["|"],[]);
                 if(llList2String(lTmp,0) == "AuthReply" && kID == "check_auth_remote")
@@ -182,13 +181,13 @@ default
                 integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
                 if(iMenuIndex!=-1){
                     string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                    g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                    g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                     list lMenuParams = llParseString2List(sStr, ["|"],[]);
                     key kAv = llList2Key(lMenuParams,0);
                     string sMsgx = llList2String(lMenuParams,1);
                     integer iPage = llList2Integer(lMenuParams,2);
                     integer iAuth = llList2Integer(lMenuParams,3);
-                    
+
                     if(sMenu == "Menu~Main"){
                         if(sMsgx == UPMENU) LM("from_addon", iAuth, "menu Addons", kAv);
                         else if(sMsgx == "+ Favorite"){
@@ -221,14 +220,14 @@ default
                             list lSeg = llParseString2List(sMsgx, [" "],[]);
                             integer cBoxMode = llListFindList(g_lCheckboxes, [llList2String(lSeg, 0)]);
                             string label = llDumpList2String(llList2List(lSeg,1,-1), " ");
-                            
+
                             integer mask = (integer)llList2String(g_lBTNS, llListFindList(g_lBTNS,[label])+2);
                             if(cBoxMode)g_iBitMask = g_iBitMask - mask;
                             else g_iBitMask += mask;
-                            
+
                             //llMessageLinked(LINK_SET, -5, (string)g_iBitMask, "");
-                            
-                            
+
+
                             MenuButtons(kAv,iAuth, iPage);
                         }
                     }
@@ -236,7 +235,7 @@ default
             }
         } else if(iNums ==-1){
             g_lMenuIDs=[];
-            
+
         } else if(iNums==-10){
             llResetScript();
         } else if(iNums == -3)

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -44,24 +44,23 @@ integer DIALOG_TIMEOUT  = -9002;
 list g_lOptedLM     = [];
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 string UPMENU = "BACK";
 
 Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
     key kMenuID = llGenerateKey();
-    
+
     llRegionSayTo(g_kCollar, API_CHANNEL, llList2Json(JSON_OBJECT, [ "pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID ]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[Menu App]";
     list lButtons  = ["A Button"];
-    
+
     //llSay(0, "opening menu");
     Dialog(kID, sPrompt, lButtons, ["DISCONNECT", UPMENU], 0, iAuth, "Menu~Main");
 }
@@ -79,7 +78,7 @@ UserCommand(integer iNum, string sStr, key kID) {
     } //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else
     {
-        //integer iWSuccess   = 0; 
+        //integer iWSuccess   = 0;
         //string sChangetype  = llList2String(llParseString2List(sStr, [" "], []),0);
         //string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         //string sText;
@@ -119,7 +118,7 @@ default
         g_iLMLastRecv = llGetUnixTime(); // Need to initialize this here in order to prevent resetting before we can receive our first pong
         llSetTimerEvent(60);
     }
-    
+
     attach(key id)
     {
         // if attached make a connectin when detached disconnect.
@@ -136,7 +135,7 @@ default
         }
     }
 
-    
+
     timer()
     {
         if (llGetUnixTime() >= (g_iLMLastSent + 30))
@@ -150,10 +149,10 @@ default
             g_kCollar = NULL_KEY;
             llResetScript(); // perform our action on disconnect
         }
-        
+
         if (g_kCollar == NULL_KEY) Link("online", 0, "", llGetOwner());
     }
-    
+
     listen(integer channel, string name, key id, string msg){
         string sPacketType = llJsonGetValue(msg, ["pkt_type"]);
         if (sPacketType == "approved" && g_kCollar == NULL_KEY)
@@ -180,14 +179,14 @@ default
                 integer iNum = (integer) llJsonGetValue(msg, ["iNum"]);
                 string sStr  = llJsonGetValue(msg, ["sMsg"]);
                 key kID      = (key) llJsonGetValue(msg, ["kID"]);
-                
+
                 if (iNum == LM_SETTING_RESPONSE)
                 {
                     list lPar     = llParseString2List(sStr, ["_","="], []);
                     string sToken = llList2String(lPar, 0);
                     string sVar   = llList2String(lPar, 1);
                     string sVal   = llList2String(lPar, 2);
-                    
+
                     if (sToken == "auth")
                     {
                         if (sVar == "owner")
@@ -199,12 +198,12 @@ default
                 else if (iNum >= CMD_OWNER && iNum <= CMD_EVERYONE)
                 {
                     UserCommand(iNum, sStr, kID);
-                    
+
                 }
                 else if (iNum == DIALOG_TIMEOUT)
                 {
                     integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                    g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 3);  //remove stride from g_lMenuIDs
+                    if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
                 }
                 else if (iNum == DIALOG_RESPONSE)
                 {
@@ -212,12 +211,12 @@ default
                     if (iMenuIndex != -1)
                     {
                         string sMenu = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                         list lMenuParams = llParseString2List(sStr, ["|"], []);
                         key kAv = llList2Key(lMenuParams, 0);
                         string sMsg = llList2String(lMenuParams, 1);
                         integer iAuth = llList2Integer(lMenuParams, 3);
-                        
+
                         if (sMenu == "Menu~Main")
                         {
                             if (sMsg == UPMENU)

--- a/src/spares/oc_debugger
+++ b/src/spares/oc_debugger
@@ -40,7 +40,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -70,7 +70,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 integer g_iDebug=TRUE;
 integer g_iOutputType = 0;
 integer g_iOutputForm = 1;
@@ -133,18 +132,18 @@ state active {
     link_message(integer iSender,integer iNum,string sStr,key kID) {
         if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) {
             UserCommand(iNum, sStr, kID);
-        } else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu) { 
+        } else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu) {
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
         } else if(iNum == DIALOG_RESPONSE) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1) {
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
-                
+
                 if(sMenu == "Menu~Main") {
                     if(sMsg == UPMENU){
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
@@ -181,7 +180,7 @@ state active {
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         }else if(iNum == DEBUG){
             /*
                 input format from other scripts is as follows

--- a/src/spares/oc_debugger.lsl
+++ b/src/spares/oc_debugger.lsl
@@ -40,7 +40,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -70,7 +70,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 integer g_iDebug=TRUE;
 integer g_iOutputType = 0;
 integer g_iOutputForm = 1;
@@ -133,18 +132,18 @@ state active {
     link_message(integer iSender,integer iNum,string sStr,key kID) {
         if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) {
             UserCommand(iNum, sStr, kID);
-        } else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu) { 
+        } else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu) {
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");
         } else if(iNum == DIALOG_RESPONSE) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1) {
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
-                
+
                 if(sMenu == "Menu~Main") {
                     if(sMsg == UPMENU){
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
@@ -181,7 +180,7 @@ state active {
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         }else if(iNum == DEBUG){
             /*
                 input format from other scripts is as follows

--- a/src/spares/oc_lock_addon_template.lsl
+++ b/src/spares/oc_lock_addon_template.lsl
@@ -43,7 +43,6 @@ integer DIALOG_TIMEOUT  = -9002;
 list g_lOptedLM     = [];
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 integer iLockAuth = 503;
 
 string UPMENU = "BACK";
@@ -54,7 +53,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llRegionSayTo(g_kCollar, API_CHANNEL, llList2Json(JSON_OBJECT, [ "pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID ]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -189,8 +188,8 @@ default
     state_entry()
     {
         initialize();
-    }    
-    
+    }
+
     on_rez(integer start_pram){
         softreset();
     }
@@ -276,7 +275,7 @@ default
                 else if (iNum == DIALOG_TIMEOUT)
                 {
                     integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                    g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 3);  //remove stride from g_lMenuIDs
+                    if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);  //remove stride from g_lMenuIDs
                 }
                 else if (iNum == DIALOG_RESPONSE)
                 {
@@ -284,7 +283,7 @@ default
                     if (iMenuIndex != -1)
                     {
                         string sMenu = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                         list lMenuParams = llParseString2List(sStr, ["|"], []);
                         key kAv = llList2Key(lMenuParams, 0);
                         string sMsg = llList2String(lMenuParams, 1);

--- a/src/spares/oc_plugin_template.lsl
+++ b/src/spares/oc_plugin_template.lsl
@@ -53,7 +53,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -75,7 +75,7 @@ UserCommand(integer iNum, string sStr, key kID) {
     if (llToLower(sStr)==llToLower(g_sSubMenu) || llToLower(sStr) == "menu "+llToLower(g_sSubMenu)) Menu(kID, iNum);
     //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else {
-        //integer iWSuccess = 0; 
+        //integer iWSuccess = 0;
         //string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
         //string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         //string sText;
@@ -85,7 +85,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 list g_lOwner;
 list g_lTrust;
 list g_lBlock;
@@ -132,12 +131,12 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
-                
+
                 if(sMenu == "Menu~Main"){
                     if(sMsg == UPMENU) llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     else if(sMsg == "A Button") llSay(0, "This is a example plugin.");
@@ -145,14 +144,14 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);  //remove stride from g_lMenuIDs
         } else if(iNum == LM_SETTING_RESPONSE){
             // Detect here the Settings
             list lSettings = llParseString2List(sStr, ["_","="],[]);
             string sToken = llList2String(lSettings,0);
             string sVar = llList2String(lSettings,1);
             string sVal = llList2String(lSettings,2);
-            
+
             if(sToken=="global"){
                 if(sVar=="locked"){
                     g_iLocked=(integer)sVal;

--- a/src/spares/oc_unwelder.lsl
+++ b/src/spares/oc_unwelder.lsl
@@ -5,10 +5,10 @@ Copyright ©2021
 Aria (Tashia Redrose)
     * Feb 2021       -       Created oc_unwelder
 Autumn Jersey (autumnerilyx.littlepaws)
-    * Aug 2022   -    Edited wording of local chat messages to improve user comprehension 
+    * Aug 2022   -    Edited wording of local chat messages to improve user comprehension
 Medea (Medea Destiny)
       Aug 2022    -  Fix for issue #862, allow wearer with trusted perm to operate
-    
+
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -52,24 +52,23 @@ integer DIALOG_TIMEOUT  = -9002;
 list g_lOptedLM     = [];
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 string UPMENU = "BACK";
 
 Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
     key kMenuID = llGenerateKey();
-    
+
     llRegionSayTo(g_kCollar, API_CHANNEL, llList2Json(JSON_OBJECT, [ "pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID ]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[OpenCollar Unwelder]\n\n* This action will break the weld on your collar. Are you sure you want to proceed?\n\n* Your owner(s) will be notified that the unweld tool was used.\n\n* Your collar will reboot immediately upon a successful unweld.";
     list lButtons  = ["UNWELD NOW"];
-    
+
     //llSay(0, "opening menu");
     Dialog(kID, sPrompt, lButtons, ["DISCONNECT", UPMENU], 0, iAuth, "Menu~Main");
 }
@@ -87,7 +86,7 @@ UserCommand(integer iNum, string sStr, key kID) {
     } //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else
     {
-        //integer iWSuccess   = 0; 
+        //integer iWSuccess   = 0;
         //string sChangetype  = llList2String(llParseString2List(sStr, [" "], []),0);
         //string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         //string sText;
@@ -145,12 +144,12 @@ default
     touch_start(integer t){
         if(g_kUser != NULL_KEY){
             if(llDetectedKey(0) == g_kUser){
-                Link("from_addon", 0, "menu "+g_sAddon, g_kUser);                
+                Link("from_addon", 0, "menu "+g_sAddon, g_kUser);
             } else {
                 llSay(0, "Unweld tool is in use, try again in a few minutes");
             }
         }else {
-            
+
     //        llSay(0, "Unwelder now in use");
             llSetText("In use by\n" + llKey2Name (llDetectedKey(0)), <1,0,0>,1);
             //llSetText("In use..", <1,0,0>,1);
@@ -160,10 +159,10 @@ default
             llListen(API_CHANNEL, "", "", "");
             Link("online", 0, "", g_kUser); // This is the signal to initiate communication between the addon and the collar
             llResetTime();
-            
+
         }
     }
-    
+
     timer()
     {
         if(llGetTime() >= 30.0 && g_kCollar==NULL_KEY && g_kUser!=NULL_KEY){
@@ -183,10 +182,10 @@ default
             softreset();
             //llResetScript(); // perform our action on disconnect
         }
-        
+
         if (g_kCollar == NULL_KEY) Link("online", 0, "", g_kUser);
     }
-    
+
     listen(integer channel, string name, key id, string msg){
         string sPacketType = llJsonGetValue(msg, ["pkt_type"]);
         if (sPacketType == "approved" && g_kCollar == NULL_KEY)
@@ -220,14 +219,14 @@ default
                 integer iNum = (integer) llJsonGetValue(msg, ["iNum"]);
                 string sStr  = llJsonGetValue(msg, ["sMsg"]);
                 key kID      = (key) llJsonGetValue(msg, ["kID"]);
-                
+
                 if (iNum == LM_SETTING_RESPONSE)
                 {
                     list lPar     = llParseString2List(sStr, ["_","="], []);
                     string sToken = llList2String(lPar, 0);
                     string sVar   = llList2String(lPar, 1);
                     string sVal   = llList2String(lPar, 2);
-                    
+
                     if (sToken == "global"){
                         if(sVar=="addonlimit"){
                             if(sVal=="0"){
@@ -239,7 +238,7 @@ default
                             g_iWelded=1;
                         }
                     }
-                    
+
                     if(sStr == "settings=sent"){
                         if(g_iAddonLimitation){
                             llSay(0, "Addons Limited is checked. To unweld, someone with Owner access (including wearer if they are Owner) must: 1) Open the collar menu. 2)Click Settings. 3) Click the Addons button in Settings. UNCHECK AddOns Limited. Leave WearerAdd and Addons CHECKED. The Wearer can then proceed to unweld.");
@@ -265,12 +264,12 @@ default
                 else if (iNum >= CMD_OWNER && iNum <= CMD_EVERYONE)
                 {
                     UserCommand(iNum, sStr, kID);
-                    
+
                 }
                 else if (iNum == DIALOG_TIMEOUT)
                 {
                     integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                    g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 3);  //remove stride from g_lMenuIDs
+                    if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1); //remove stride from g_lMenuIDs
                 }
                 else if (iNum == DIALOG_RESPONSE)
                 {
@@ -278,12 +277,12 @@ default
                     if (iMenuIndex != -1)
                     {
                         string sMenu = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                         list lMenuParams = llParseString2List(sStr, ["|"], []);
                         key kAv = llList2Key(lMenuParams, 0);
                         string sMsg = llList2String(lMenuParams, 1);
                         integer iAuth = llList2Integer(lMenuParams, 3);
-                        
+
                         if (sMenu == "Menu~Main")
                         {
                             if (sMsg == UPMENU)

--- a/src/spares/oc_unwelder_hud.lsl
+++ b/src/spares/oc_unwelder_hud.lsl
@@ -5,8 +5,8 @@ Copyright ©2021
 Aria (Tashia Redrose)
     * Feb 2021       -       Created oc_unwelder_hud
 Medea (Medea Destiny)
-      Aug 2022    -  Fix for issue #862, allow wearer with trusted perm to operate    
-    
+      Aug 2022    -  Fix for issue #862, allow wearer with trusted perm to operate
+
 et al.
 Licensed under the GPLv2. See LICENSE for full details.
 https://github.com/OpenCollarTeam/OpenCollar
@@ -50,24 +50,23 @@ integer DIALOG_TIMEOUT  = -9002;
 list g_lOptedLM     = [];
 
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 string UPMENU = "BACK";
 
 Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
     key kMenuID = llGenerateKey();
-    
+
     llRegionSayTo(g_kCollar, API_CHANNEL, llList2Json(JSON_OBJECT, [ "pkt_type", "from_addon", "addon_name", g_sAddon, "iNum", DIALOG, "sMsg", (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, "kID", kMenuID ]));
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [ kID, kMenuID, sName ], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[OpenCollar Unwelder]\n\n* This action will break the weld on your collar. Are you sure you want to proceed?\n\n* Your owner(s) will be notified that the unweld tool was used.\n\n* Your collar will reboot immediately upon a successful unweld.";
     list lButtons  = ["UNWELD NOW"];
-    
+
     //llOwnerSay("opening menu");
     Dialog(kID, sPrompt, lButtons, ["DISCONNECT", UPMENU], 0, iAuth, "Menu~Main");
 }
@@ -85,7 +84,7 @@ UserCommand(integer iNum, string sStr, key kID) {
     } //else if (iNum!=CMD_OWNER && iNum!=CMD_TRUSTED && kID!=g_kWearer) RelayNotify(kID,"Access denied!",0);
     else
     {
-        //integer iWSuccess   = 0; 
+        //integer iWSuccess   = 0;
         //string sChangetype  = llList2String(llParseString2List(sStr, [" "], []),0);
         //string sChangevalue = llList2String(llParseString2List(sStr, [" "], []),1);
         //string sText;
@@ -146,7 +145,7 @@ default
         llListen(API_CHANNEL, "", "", "");
         Link("online", 0, "", g_kUser); // This is the signal to initiate communication between the addon and the collar
     }
-    
+
     attach(key kID){
         if(kID==NULL_KEY){
             // detaching
@@ -155,7 +154,7 @@ default
             llResetScript();
         }
     }
-    
+
     timer()
     {
         if (llGetUnixTime() >= (g_iLMLastSent + 30))
@@ -170,10 +169,10 @@ default
             softreset();
             //llResetScript(); // perform our action on disconnect
         }
-        
+
         if (g_kCollar == NULL_KEY) Link("online", 0, "", g_kUser);
     }
-    
+
     listen(integer channel, string name, key id, string msg){
         string sPacketType = llJsonGetValue(msg, ["pkt_type"]);
         if (sPacketType == "approved" && g_kCollar == NULL_KEY)
@@ -207,14 +206,14 @@ default
                 integer iNum = (integer) llJsonGetValue(msg, ["iNum"]);
                 string sStr  = llJsonGetValue(msg, ["sMsg"]);
                 key kID      = (key) llJsonGetValue(msg, ["kID"]);
-                
+
                 if (iNum == LM_SETTING_RESPONSE)
                 {
                     list lPar     = llParseString2List(sStr, ["_","="], []);
                     string sToken = llList2String(lPar, 0);
                     string sVar   = llList2String(lPar, 1);
                     string sVal   = llList2String(lPar, 2);
-                    
+
                     if (sToken == "global"){
                         if(sVar=="addonlimit"){
                             if(sVal=="0"){
@@ -226,7 +225,7 @@ default
                             g_iWelded=1;
                         }
                     }
-                    
+
                     if(sStr == "settings=sent"){
                         if(g_iAddonLimitation){
                             llOwnerSay("Addons Limited is checked. To unweld, someone with Owner access (including wearer if they are Owner) must: 1) Open the collar menu. 2)Click Settings. 3) Click the Addons button in Settings. UNCHECK AddOns Limited. Leave WearerAdd and Addons CHECKED. The Wearer can then proceed to unweld.");
@@ -252,12 +251,12 @@ default
                 else if (iNum >= CMD_OWNER && iNum <= CMD_EVERYONE)
                 {
                     UserCommand(iNum, sStr, kID);
-                    
+
                 }
                 else if (iNum == DIALOG_TIMEOUT)
                 {
                     integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                    g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 3);  //remove stride from g_lMenuIDs
+                    if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1)  //remove stride from g_lMenuIDs
                 }
                 else if (iNum == DIALOG_RESPONSE)
                 {
@@ -265,12 +264,12 @@ default
                     if (iMenuIndex != -1)
                     {
                         string sMenu = llList2String(g_lMenuIDs, iMenuIndex + 1);
-                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex - 2 + g_iMenuStride);
+                        g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);
                         list lMenuParams = llParseString2List(sStr, ["|"], []);
                         key kAv = llList2Key(lMenuParams, 0);
                         string sMsg = llList2String(lMenuParams, 1);
                         integer iAuth = llList2Integer(lMenuParams, 3);
-                        
+
                         if (sMenu == "Menu~Main")
                         {
                             if (sMsg == UPMENU)
@@ -284,7 +283,7 @@ default
                                     llOwnerSay("Consent : Valid");
                                     Link("from_addon", LM_SETTING_DELETE, "intern_weld","origin");
                                     llOwnerSay("Weld is now broken");
-                                    
+
                                     llRemoveInventory(llGetScriptName()); // delete unwelder script after use
                                 }else{
                                     llOwnerSay("This tool cannot be used by someone with public access, your collar access level must be owner or wearer");

--- a/src/spares/oc_unwelder_hud.lsl
+++ b/src/spares/oc_unwelder_hud.lsl
@@ -256,7 +256,7 @@ default
                 else if (iNum == DIALOG_TIMEOUT)
                 {
                     integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-                    if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1)  //remove stride from g_lMenuIDs
+                    if (~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex + 1);  //remove stride from g_lMenuIDs
                 }
                 else if (iNum == DIALOG_RESPONSE)
                 {

--- a/src/spares/plugin_test_debugger.lsl
+++ b/src/spares/plugin_test_debugger.lsl
@@ -45,7 +45,7 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
     llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
 
     integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);
     else g_lMenuIDs += [kID, kMenuID, sName];
 }
 
@@ -71,7 +71,6 @@ UserCommand(integer iNum, string sStr, key kID) {
 
 key g_kWearer;
 list g_lMenuIDs;
-integer g_iMenuStride;
 
 integer ALIVE = -55;
 integer READY = -56;
@@ -115,12 +114,12 @@ state active
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             if(iMenuIndex!=-1){
                 string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
-                
+
                 if(sMenu == "Menu~Main"){
                     if(sMsg == UPMENU){
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
@@ -138,7 +137,7 @@ state active
             }
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+            if(~iMenuIndex) g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1); //remove stride from g_lMenuIDs
         }
     }
 }


### PR DESCRIPTION
added check "iMenuIndex" in  DIALOG_TOMEOUT  (  ~iMenuIndex equals iMenuIndex != -1  ) for proper removal stride from list g_lMenuIDs

there are many mistakes!
in many scripts it was forgotten to specify a constant: g_iMenuStride=3 
important! this constant determines the size of the strides in the list g_lMenuIDs

since the size of the strides in the list is always 3, there is a reason to replace it with a numerical constant in relevant functions

in Dialog() it looks like this:
if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
will be equal to:
if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + 2);

in "DIALOG_SESPONSE" and "DIALOG_TIMEOUT" it looks like this: g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex+1);

some tail spaces removed (sorry)

p.s. sorry for my bad English :(