### PR TITLE
Create oc_weld

### DIFF
--- a/src/collar/oc_weld
+++ b/src/collar/oc_weld
@@ -1,47 +1,28 @@
-string g_sSubmenu = "Main";
-string g_sButton = "Weld";
+string g_sApp = "Weld";
 
-integer g_iRespring;
+key g_kWelder;
 
-//MESSAGE MAP
-//integer CMD_ZERO = 0;
 integer CMD_OWNER = 500;
 //integer CMD_TRUSTED = 501;
 //integer CMD_GROUP = 502;
-//integer CMD_WEARER = 503;
-integer CMD_EVERYONE = 504;
-//integer CMD_RLV_RELAY = 507;
-//integer CMD_SAFEWORD = 510;
-//integer CMD_RELAY_SAFEWORD = 511;
-//integer CMD_NOACCESS=599;
+integer CMD_WEARER = 503;
+//integer CMD_EVERYONE = 504;
 
 integer NOTIFY = 1002;
 integer NOTIFY_OWNERS=1003;
 //integer REBOOT = -1000;
 
-integer LM_SETTING_SAVE = 2000;//scripts send messages on this channel to have settings saved
-//str must be in form of "token=value"
-//integer LM_SETTING_REQUEST = 2001;//when startup, scripts send requests for settings on this channel
-//integer LM_SETTING_RESPONSE = 2002;//the settings script sends responses on this channel
-//integer LM_SETTING_DELETE = 2003;//delete token from settings
-//integer LM_SETTING_EMPTY = 2004;//sent when a token has no value
+integer LM_SETTING_SAVE = 2000;
+
 
 integer MENUNAME_REQUEST = 3000;
 integer MENUNAME_RESPONSE = 3001;
-integer MENUNAME_REMOVE = 3003;
+//integer MENUNAME_REMOVE = 3003;
 
-//integer RLV_CMD = 6000;
-//integer RLV_REFRESH = 6001;//RLV plugins should reinstate their restrictions upon receiving this message.
+integer TIMEOUT_FIRED = 30499;
 
-//integer RLV_OFF = 6100; // send to inform plugins that RLV is disabled now, no message or key needed
-//integer RLV_ON = 6101; // send to inform plugins that RLV is enabled now, no message or key needed
-
-//integer TIMEOUT_READY = 30497;
-//integer TIMEOUT_REGISTER = 30498;
-//integer TIMEOUT_FIRED = 30499;
-
-//integer AUTH_REQUEST = 600;
-//integer AUTH_REPLY=601;
+integer AUTH_REQUEST = 600;
+integer AUTH_REPLY=601;
 
 integer DIALOG = -9000;
 integer DIALOG_RESPONSE = -9001;
@@ -49,32 +30,40 @@ integer DIALOG_TIMEOUT = -9002;
 //string UPMENU = "BACK";
 //string ALL = "ALL";
 
-integer ADD = 1;
-integer DELETE = 2;
 
 
+Dialog(key kAv, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
+    
+    if(sName == "weld"){
+        sPrompt = "weldby:"+llLinksetDataRead("intern_weldby");
+        if((integer)llLinksetDataRead("intern_weld")){
+            sPrompt = "\n\n* This collar is Welded by secondlife:///app/agent/"+llLinksetDataRead("intern_weldby")+"/about *";
+            sPrompt += "\n\nThe unwelder is located at\n[http://maps.secondlife.com/secondlife/KBar%20West/28/80/1201 OpenCollar headquarters]";
+            lChoices = ["w̶e̶l̶d̶e̶d̶"];
+            
+        }else{
+            sPrompt="\n\nThis app will let you weld the collar.\nWhich removes the ability to unlock.\n\n⚠ Proceed with caution ⚠\nWelding is semi-perminent and can only be undone with the use of an external unwelder.";
 
-list g_lMenuIDs;
-Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
-    key kMenuID = llGenerateKey();
-    llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
-
-    integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex - 1);
-    else g_lMenuIDs += [kID, kMenuID, sName];
+            if(!(integer)llLinksetDataRead("global_locked")){
+                sPrompt += "\n\nThe collar is not locked yet.\nBefore you can weld, you must lock it first.";
+                lChoices = ["Lock"];
+            }else{
+                lChoices = ["Weld Now"];
+            }
+        }
+        lChoices += ["Help","BACK"];
+    }
+    
+    llMessageLinked(LINK_SET, DIALOG, (string)kAv + "|" + sPrompt + "\n|"+(string)iPage+"|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, sName+"~"+llGetScriptName());
 }
 
-UserCommand(integer iAuth, string sStr, key kID) {
+UserCommand(integer iAuth, string sStr, key kAv) {
     list lParameters = llParseString2List(sStr, [" "], []);
     string sChangetype = llList2String(lParameters,0);
     string sChangevalue = llList2String(lParameters,1);
     if(sChangetype == "menu"){
-        if(sChangevalue == g_sButton){ // Weld button pressed
-            if(iAuth==CMD_OWNER){
-                llLinksetDataWrite("intern_weldby", kID);
-                llMessageLinked(LINK_SET, NOTIFY, "1secondlife:///app/agent/"+(string)kID+"/about is attempting to weld the collar. Consent is required", kID);
-                Dialog(llGetOwner(), "[WELD CONSENT REQUIRED]\n\nsecondlife:///app/agent/"+(string)kID+"/about wants to weld your collar. If you agree, you may not be able to unweld it without the use of a plugin or a addon designed to break the weld. If you disagree with this action, press no.", ["Yes", "No"], [], 0, iAuth, "weld~consent");
-            } else llMessageLinked(LINK_SET,NOTIFY,"0%NOACCESS% to welding", kID);
+        if(sChangevalue == g_sApp){ // Weld button pressed
+            Dialog(kAv,"",[],[],0,iAuth,"weld");
         }
     }
 }
@@ -85,97 +74,71 @@ default
     }
     
     link_message(integer iSender,integer iNum,string sStr,key kID){
-        if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) {
+        if(iNum >= CMD_OWNER && iNum <= CMD_WEARER) {
             UserCommand(iNum, sStr, kID);
             
-        } else if(iNum == DIALOG_RESPONSE){
-            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if(iMenuIndex!=-1){
-                string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2);
-                
+        }else if (iNum == MENUNAME_REQUEST  && sStr == "Apps") {
+            //llLinksetDataWrite("Menu_Apps_"+g_sApp,"1");/*/
+            llMessageLinked(LINK_SET, MENUNAME_RESPONSE, "Apps|"+g_sApp, "");//*/
+            
+        } else if(iNum == DIALOG_RESPONSE){          
+            integer iPos = llSubStringIndex((string)kID, "~"+llGetScriptName());
+            if(iPos>0){
+                string sMenu = llGetSubString(kID, 0, iPos-1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sButton = llList2String(lMenuParams,1);
                 integer iAuth = llList2Integer(lMenuParams,3);
                 
-                if(sMenu == "weld~consent"){
+                if(sMenu == "weld"){
+                    if(sButton == "Weld Now"){
+                        if(iAuth==CMD_OWNER){
+                            if((integer)llLinksetDataRead("global_locked")){
+                                g_kWelder = kAv;
+                                                                
+                                llMessageLinked(LINK_SET, NOTIFY, "1secondlife:///app/agent/"+(string)g_kWelder+"/about is attempting to weld the collar. Consent is required", kAv);
+                                Dialog(llGetOwner(), "[WELD CONSENT REQUIRED]\n\nsecondlife:///app/agent/"+(string)kAv+"/about wants to weld your collar. If you agree, you may not be able to unweld it without the use of a plugin or a addon designed to break the weld. If you disagree with this action, press no.", ["Yes", "No"], [], 0, iAuth, "weld~consent");
+                            } else {
+                                llMessageLinked(LINK_SET,NOTIFY,"0You have to first lock the collar before you can weld it", kAv);
+                            }
+                        } else llMessageLinked(LINK_SET,NOTIFY,"0%NOACCESS% to welding", kAv);
+                        
+                    }else if(sButton == "w̶e̶l̶d̶e̶d̶"){
+                        Dialog(kAv,"",[],[],0,iAuth,"weld");
+                        
+                    }else if(sButton == "Lock"){
+                        llMessageLinked(LINK_SET, 0, "lock", kAv);
+                        llSleep(1);
+                        Dialog(kAv,"",[],[],0,iAuth,"weld");
+                        
+                    }else if(sButton == "Help"){
+                        llLoadURL(kAv, "\n\nGo to page for the Weld and Unweld guide.\n\n", "https://opencollar.cc/docs/Weld");
+                        
+                    }else if(sButton == "BACK"){
+                        llMessageLinked(LINK_SET, iAuth, "menu Apps", kAv);
+                    }
+                }else if(sMenu == "weld~consent"){
                     if(sButton == "No"){
-                        llMessageLinked(LINK_SET, NOTIFY, "1%NOACCESS% to welding the collar.", llLinksetDataRead("intern_weldby"));
+                        llMessageLinked(LINK_SET, NOTIFY, "1%NOACCESS% to welding the collar.", g_kWelder);
+                        llMessageLinked(LINK_SET, 0, "menu Weld", g_kWelder);
+                        
                     } else {
                         // do weld
-                        llMessageLinked(LINK_SET, NOTIFY, "1Please wait...", llLinksetDataRead("intern_weldby"));
-                        llMessageLinked(LINK_SET, LM_SETTING_SAVE, "intern_weld=1", llLinksetDataRead("intern_weldby"));
-                        g_iRespring = TRUE;
+                        if(g_kWelder){
+                            /*
+                            llLinksetDataWrite("intern_weldby",g_kWelder);
+                            llLinksetDataWrite("intern_weld","1");
+                            /*/                            
+                            llMessageLinked(LINK_SET, LM_SETTING_SAVE, "intern_weld=1", "");
+                            llMessageLinked(LINK_SET, LM_SETTING_SAVE, "intern_weldby="+(string)g_kWelder, ""); 
+                            //*/
+                            llMessageLinked(LINK_SET, NOTIFY_OWNERS, "%WEARERNAME%'s collar has been welded", g_kWelder);
+                            llMessageLinked(LINK_SET, NOTIFY, "1Weld completed", llGetOwner());
+                            
+                            llMessageLinked(LINK_SET, 0, "menu Weld", g_kWelder);
+                        }
                     }
-                }
-            }        
-        } else if (iNum == DIALOG_TIMEOUT) {
-            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
-        }
-        
-    }
-    
-    linkset_data( integer iAction, string sToken, string sValue ){
-        list lToken = llParseString2List(sToken, ["_"],[]);
-        string sGroup = llList2String(lToken,0);
-        string sVar = llList2String(lToken,1);
-        integer iValue = (integer)sValue;
-                
-        integer iWeldButton;
-                     
-        if (sGroup == "global"){
-            if(sVar == "locked"){
-                if(iAction == LINKSETDATA_UPDATE && sValue == "1"){
-                    iWeldButton = ADD;
-                      
-                } else if (sValue!="1"){
-                    if(llLinksetDataRead("intern_weld")=="1"){
-                        llLinksetDataWrite("global_locked","1"); // when welded, it should be locked
-                    }
-                    iWeldButton = DELETE;
-                }
-            } else if (sVar == "hideweld"){ // flag to remove the weld button
-                if(iAction == LINKSETDATA_UPDATE && sValue=="1"){
-                    iWeldButton = DELETE;
-                    
-                } else if (sValue!="1"){
-                    iWeldButton = ADD;
-                }
-            }
-        } else if (sGroup == "intern"){
-            if(sVar == "weld"){
-                if(iAction == LINKSETDATA_UPDATE && sValue=="1"){
-                    iWeldButton = DELETE;
-                    
-                } else if (sValue!="1"){
-                    iWeldButton = ADD;
-                }
-            }
-        }
-        
-        if(iWeldButton){
-            list lButtons = llCSV2List(llLinksetDataRead("Menu_"+g_sSubmenu));
-            integer loc = llListFindList(lButtons, [g_sButton]);
-            if(iWeldButton == ADD){
-                if(llLinksetDataRead("intern_weld")!="1" && llLinksetDataRead("global_locked")=="1" && llLinksetDataRead("global_hideweld")!="1"){
-                    if(!~loc){
-                        lButtons += g_sButton;
-                        llLinksetDataWrite("Menu_"+g_sSubmenu, llList2CSV(lButtons));
-                    }
-                }
-            } else if(iWeldButton == DELETE){
-                while(~loc){
-                    lButtons = llDeleteSubList(lButtons, loc,loc);
-                    llLinksetDataWrite("Menu_"+g_sSubmenu, llList2CSV(lButtons));
-                    loc = llListFindList(lButtons, [g_sButton]);
-                }
-                if(g_iRespring){
-                    llMessageLinked(LINK_SET, NOTIFY_OWNERS, "%WEARERNAME%'s collar has been welded", llLinksetDataRead("intern_weldby"));
-                    llMessageLinked(LINK_SET, NOTIFY, "1Weld completed", llGetOwner()); //We shouldn't have to send this to the welder. Welder should always be an owner.
-                    llMessageLinked(LINK_SET, 0, "menu Main", llLinksetDataRead("intern_weldby"));
-                    g_iRespring = FALSE;
+                    g_kWelder = NULL_KEY;
                 }
             }
         }

--- a/src/collar/oc_weld
+++ b/src/collar/oc_weld
@@ -1,0 +1,183 @@
+string g_sSubmenu = "Main";
+string g_sButton = "Weld";
+
+integer g_iRespring;
+
+//MESSAGE MAP
+//integer CMD_ZERO = 0;
+integer CMD_OWNER = 500;
+//integer CMD_TRUSTED = 501;
+//integer CMD_GROUP = 502;
+//integer CMD_WEARER = 503;
+integer CMD_EVERYONE = 504;
+//integer CMD_RLV_RELAY = 507;
+//integer CMD_SAFEWORD = 510;
+//integer CMD_RELAY_SAFEWORD = 511;
+//integer CMD_NOACCESS=599;
+
+integer NOTIFY = 1002;
+integer NOTIFY_OWNERS=1003;
+//integer REBOOT = -1000;
+
+integer LM_SETTING_SAVE = 2000;//scripts send messages on this channel to have settings saved
+//str must be in form of "token=value"
+//integer LM_SETTING_REQUEST = 2001;//when startup, scripts send requests for settings on this channel
+//integer LM_SETTING_RESPONSE = 2002;//the settings script sends responses on this channel
+//integer LM_SETTING_DELETE = 2003;//delete token from settings
+//integer LM_SETTING_EMPTY = 2004;//sent when a token has no value
+
+integer MENUNAME_REQUEST = 3000;
+integer MENUNAME_RESPONSE = 3001;
+integer MENUNAME_REMOVE = 3003;
+
+//integer RLV_CMD = 6000;
+//integer RLV_REFRESH = 6001;//RLV plugins should reinstate their restrictions upon receiving this message.
+
+//integer RLV_OFF = 6100; // send to inform plugins that RLV is disabled now, no message or key needed
+//integer RLV_ON = 6101; // send to inform plugins that RLV is enabled now, no message or key needed
+
+//integer TIMEOUT_READY = 30497;
+//integer TIMEOUT_REGISTER = 30498;
+//integer TIMEOUT_FIRED = 30499;
+
+//integer AUTH_REQUEST = 600;
+//integer AUTH_REPLY=601;
+
+integer DIALOG = -9000;
+integer DIALOG_RESPONSE = -9001;
+integer DIALOG_TIMEOUT = -9002;
+//string UPMENU = "BACK";
+//string ALL = "ALL";
+
+integer ADD = 1;
+integer DELETE = 2;
+
+
+
+list g_lMenuIDs;
+Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
+    key kMenuID = llGenerateKey();
+    llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
+
+    integer iIndex = llListFindList(g_lMenuIDs, [kID]);
+    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex - 1);
+    else g_lMenuIDs += [kID, kMenuID, sName];
+}
+
+UserCommand(integer iAuth, string sStr, key kID) {
+    list lParameters = llParseString2List(sStr, [" "], []);
+    string sChangetype = llList2String(lParameters,0);
+    string sChangevalue = llList2String(lParameters,1);
+    if(sChangetype == "menu"){
+        if(sChangevalue == g_sButton){ // Weld button pressed
+            if(iAuth==CMD_OWNER){
+                llLinksetDataWrite("intern_weldby", kID);
+                llMessageLinked(LINK_SET, NOTIFY, "1secondlife:///app/agent/"+(string)kID+"/about is attempting to weld the collar. Consent is required", kID);
+                Dialog(llGetOwner(), "[WELD CONSENT REQUIRED]\n\nsecondlife:///app/agent/"+(string)kID+"/about wants to weld your collar. If you agree, you may not be able to unweld it without the use of a plugin or a addon designed to break the weld. If you disagree with this action, press no.", ["Yes", "No"], [], 0, iAuth, "weld~consent");
+            } else llMessageLinked(LINK_SET,NOTIFY,"0%NOACCESS% to welding", kID);
+        }
+    }
+}
+
+default
+{
+    state_entry(){
+    }
+    
+    link_message(integer iSender,integer iNum,string sStr,key kID){
+        if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) {
+            UserCommand(iNum, sStr, kID);
+            
+        } else if(iNum == DIALOG_RESPONSE){
+            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
+            if(iMenuIndex!=-1){
+                string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
+                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2);
+                
+                list lMenuParams = llParseString2List(sStr, ["|"],[]);
+                key kAv = llList2Key(lMenuParams,0);
+                string sButton = llList2String(lMenuParams,1);
+                integer iAuth = llList2Integer(lMenuParams,3);
+                
+                if(sMenu == "weld~consent"){
+                    if(sButton == "No"){
+                        llMessageLinked(LINK_SET, NOTIFY, "1%NOACCESS% to welding the collar.", llLinksetDataRead("intern_weldby"));
+                    } else {
+                        // do weld
+                        llMessageLinked(LINK_SET, NOTIFY, "1Please wait...", llLinksetDataRead("intern_weldby"));
+                        llMessageLinked(LINK_SET, LM_SETTING_SAVE, "intern_weld=1", llLinksetDataRead("intern_weldby"));
+                        g_iRespring = TRUE;
+                    }
+                }
+            }        
+        } else if (iNum == DIALOG_TIMEOUT) {
+            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
+            g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
+        }
+        
+    }
+    
+    linkset_data( integer iAction, string sToken, string sValue ){
+        list lToken = llParseString2List(sToken, ["_"],[]);
+        string sGroup = llList2String(lToken,0);
+        string sVar = llList2String(lToken,1);
+        integer iValue = (integer)sValue;
+                
+        integer iWeldButton;
+                     
+        if (sGroup == "global"){
+            if(sVar == "locked"){
+                if(iAction == LINKSETDATA_UPDATE && sValue == "1"){
+                    iWeldButton = ADD;
+                      
+                } else if (sValue!="1"){
+                    if(llLinksetDataRead("intern_weld")=="1"){
+                        llLinksetDataWrite("global_locked","1"); // when welded, it should be locked
+                    }
+                    iWeldButton = DELETE;
+                }
+            } else if (sVar == "hideweld"){ // flag to remove the weld button
+                if(iAction == LINKSETDATA_UPDATE && sValue=="1"){
+                    iWeldButton = DELETE;
+                    
+                } else if (sValue!="1"){
+                    iWeldButton = ADD;
+                }
+            }
+        } else if (sGroup == "intern"){
+            if(sVar == "weld"){
+                if(iAction == LINKSETDATA_UPDATE && sValue=="1"){
+                    iWeldButton = DELETE;
+                    
+                } else if (sValue!="1"){
+                    iWeldButton = ADD;
+                }
+            }
+        }
+        
+        if(iWeldButton){
+            list lButtons = llCSV2List(llLinksetDataRead("Menu_"+g_sSubmenu));
+            integer loc = llListFindList(lButtons, [g_sButton]);
+            if(iWeldButton == ADD){
+                if(llLinksetDataRead("intern_weld")!="1" && llLinksetDataRead("global_locked")=="1" && llLinksetDataRead("global_hideweld")!="1"){
+                    if(!~loc){
+                        lButtons += g_sButton;
+                        llLinksetDataWrite("Menu_"+g_sSubmenu, llList2CSV(lButtons));
+                    }
+                }
+            } else if(iWeldButton == DELETE){
+                while(~loc){
+                    lButtons = llDeleteSubList(lButtons, loc,loc);
+                    llLinksetDataWrite("Menu_"+g_sSubmenu, llList2CSV(lButtons));
+                    loc = llListFindList(lButtons, [g_sButton]);
+                }
+                if(g_iRespring){
+                    llMessageLinked(LINK_SET, NOTIFY_OWNERS, "%WEARERNAME%'s collar has been welded", llLinksetDataRead("intern_weldby"));
+                    llMessageLinked(LINK_SET, NOTIFY, "1Weld completed", llGetOwner()); //We shouldn't have to send this to the welder. Welder should always be an owner.
+                    llMessageLinked(LINK_SET, 0, "menu Main", llLinksetDataRead("intern_weldby"));
+                    g_iRespring = FALSE;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replaces the functionality of Weld but in it's on script now (was spread between oc_core and oc_settings).

Using LinksetData instead of prim description for settings, which also allows the Weld button from being dynamically added and removed. 

Most weld dependencies in oc_settings should now be redundant and could be removed.  Already removed (commented out) weld from oc_core in #943