### PR TITLE
Update oc_rlvsuite.lsl

### DIFF
--- a/src/collar/oc_rlvsuite.lsl
+++ b/src/collar/oc_rlvsuite.lsl
@@ -110,7 +110,7 @@ string Checkbox(integer iValue, string sLabel) {
 
 
 // Default presets will look like the old oc_rlvsuite Buttons
-list g_lMacros = ["Hear", 4, 0, "Talk" , 3, 0, "Touch", 0, 16384, "Stray", 29360128, 524288, "Inventory", 1342179328, 96, "Dress", 0, 30, "IM", 384, 0, "Names/Map", 323584, 0, "Blur", 0, 33554432];
+list g_lMacros = ["Hear", 4, 0, "Talk" , 3, 0, "Touch", 0, 16384, "Stray", 29360128, 1048576, "Inventory", 1342179328, 96, "Dress", 0, 30, "IM", 384, 0, "Names/Map", 323584, 0, "Blur", 0, 33554432];
 /*NOTE: When changing these values for defaults, they should also be changed in the restrictions~restore section of dialogue response in link_message event, where this variable is restored to default settings. This is hardcoded inthe dialog response to save storing defaults and current as separate permanent lists*/
 
 


### PR DESCRIPTION
Stray restriction sets sit instead of sittp (instructions say it stops you sitting on things unless you're standing right next to them, which is sittp, it currently sets sit). This fix changes the stray restriction values for sittp rather than sit. 

Untested in world so far, someone just brought it up in the group so I put in the fix, so needs checking before approving the pull, but there shouldn't be an issue unless I've typod or done something dumb!