### PR TITLE
Update oc_core.lsl for wearer setting of safeword and device name

### DIFF
--- a/src/collar/oc_core.lsl
+++ b/src/collar/oc_core.lsl
@@ -268,7 +268,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                 if(iNum==CMD_OWNER) {
                     llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_safeworddisable=1", "");
                     llMessageLinked(LINK_SET,NOTIFY,"1Safeword Disabled.",kID);
-                } else llOwnerSay("Only an owner can disable Safeword!");
+                } else llMessageLinked(LINK_SET,NOTIFY,"0Only an owner can disable Safeword!",kID);
                 return;
             } else if(sChangevalue!="") {
                 if(g_iSafewordDisable==TRUE && iNum!=CMD_OWNER) {
@@ -280,7 +280,10 @@ UserCommand(integer iNum, string sStr, key kID) {
                 llMessageLinked(LINK_SET,NOTIFY,"1Safeword is now set to '"+sChangevalue+"'.",kID);
                 llMessageLinked(LINK_SET, LM_SETTING_DELETE, "global_safeworddisable","");
                 llMessageLinked(LINK_SET, CMD_OWNER, "safeword-enable","");
-            } else llMessageLinked(LINK_SET, NOTIFY, "0The safeword is current set to: '"+g_sSafeword+"'",kID);
+            } else {
+                if(g_iSafewordDisable) llMessageLinked(LINK_SET, NOTIFY, "0The safeword is currently disabled.",kID);
+                else llMessageLinked(LINK_SET, NOTIFY, "0The safeword is currently set to: '"+g_sSafeword+"'",kID);
+            }
         } else if(sChangetype == "menu"){
             if(llToLower(sChangevalue) == "access"){
                 Dialog(kID,"",[],[],0,iNum,"Menu~Auth");
@@ -322,7 +325,7 @@ UserCommand(integer iNum, string sStr, key kID) {
             }
             llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_wearername="+sChangevalue, "");
             llSleep(0.5);
-            llMessageLinked(LINK_SET, NOTIFY, "0The wearer's name is now set to %WEARERNAME% (if this is the old name, please type '/1 (prefix) name' to confirm the change went through, we may just have lagged)", kID);
+            llMessageLinked(LINK_SET, NOTIFY, "1The wearer's name is now set to %WEARERNAME% (if this is the old name, please type '/1 (prefix) name' to confirm the change went through, we may just have lagged)", kID);
         } else if(llToLower(sChangetype) == "device"){
             if(iNum!=CMD_OWNER && kID!=g_kWearer){
                 llMessageLinked(LINK_THIS,NOTIFY,"No access to device name.",kID);
@@ -337,7 +340,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                 }
                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_devicename="+sChangevalue,"");
                 llSleep(0.5); //To ensure the notify happens AFTER the new device name is in place.
-                llMessageLinked(LINK_SET, NOTIFY, "0The device name is now set to: %DEVICENAME% (if this is the old name, please type '/1 (prefix) device name' to confirm the change went through, we may just have lagged)", kID);
+                llMessageLinked(LINK_SET, NOTIFY, "1The device name is now set to: %DEVICENAME% (if this is the old name, please type '/1 (prefix) device name' to confirm the change went through, we may just have lagged)", kID);
             }
         } else if(llToLower(sChangetype) == "allowhide"){
             if(iNum == CMD_OWNER){

--- a/src/collar/oc_core.lsl
+++ b/src/collar/oc_core.lsl
@@ -68,6 +68,7 @@ integer g_iVerbosityLevel=1;
 integer g_iNotifyInfo=FALSE;
 
 string g_sSafeword="RED";
+integer g_iSafewordDisable=0;
 //MESSAGE MAP
 //integer CMD_ZERO = 0;
 integer CMD_OWNER = 500;
@@ -257,7 +258,7 @@ UserCommand(integer iNum, string sStr, key kID) {
             } else llMessageLinked(LINK_SET, NOTIFY, "0%NOACCESS% to update the collar", kID);
         } else if(sChangetype == "safeword") {
             if(iNum!=CMD_OWNER && kID!=g_kWearer) {
-                llMessageLinked(LINK_SET,NOTIFY,"No access to safeword!",kID);
+                llMessageLinked(LINK_SET,NOTIFY,"0No access to safeword!",kID);
                 return;
             } if(llToLower(sChangevalue) == "off") {
                 if(iNum==CMD_OWNER) {
@@ -266,6 +267,10 @@ UserCommand(integer iNum, string sStr, key kID) {
                 } else llOwnerSay("Only an owner can disable Safeword!");
                 return;
             } else if(sChangevalue!="") {
+                if(g_iSafewordDisable==TRUE && iNum!=CMD_OWNER) {
+                    llMessageLinked(LINK_SET,NOTIFY,"0Only Owners can set a safeword when disabled!",kID);
+                    return;
+                }
                 if(sChangevalue == "RED") llMessageLinked(LINK_SET, LM_SETTING_DELETE, "global_safeword","");
                 else llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_safeword="+sChangevalue,"");
                 llMessageLinked(LINK_SET,NOTIFY,"1Safeword is now set to '"+sChangevalue+"'.",kID);
@@ -723,6 +728,8 @@ state active
                     }
                 } else if(sVar == "safeword"){
                     g_sSafeword = sVal;
+                } else if(sVar == "safeworddisable"){
+                    g_iSafewordDisable=1;
                 } else if(sVar == "prefix"){
                     g_sPrefix = sVal;
                 } else if(sVar == "channel"){
@@ -792,7 +799,9 @@ state active
                     g_iLocked=FALSE;
                     llOwnerSay("@detach=y");
                 }
-                else if(sVar == "safeword"){
+                else if(sVar == "safeworddisable"){
+                    g_iSafewordDisable=0;
+                } else if(sVar == "safeword"){
                     g_sSafeword = "RED";
                     llMessageLinked(LINK_SET, CMD_OWNER, "safeword-enable","");
                 } else if(sVar == "prefix"){

--- a/src/collar/oc_core.lsl
+++ b/src/collar/oc_core.lsl
@@ -38,7 +38,11 @@ Medea (Medea Destiny)
                     off is clearly notified. Wearer can now set their own safeword, but only owners can disable it still.
                     See issue # 986. Attempting to access safeword without permission now gives no access response. 
                 -   Provide no access notification for device name, and allow non-owner wearer to name. Notify wearer
-                    as well when another person changes device name. See issue # 987           
+                    as well when another person changes device name. See issue # 987 
+   Jul 2024     -   Further work on above safeword stuff, see PR #999 
+                -   added delay after name change to ensure report is correct and added clarification text here
+                    and in device name. Issue #1053
+                            
 Stormed Darkshade (StormedStormy)
     March 2022  -   Added a button for reboot to help/about menu.  
 
@@ -275,6 +279,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                 else llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_safeword="+sChangevalue,"");
                 llMessageLinked(LINK_SET,NOTIFY,"1Safeword is now set to '"+sChangevalue+"'.",kID);
                 llMessageLinked(LINK_SET, LM_SETTING_DELETE, "global_safeworddisable","");
+                llMessageLinked(LINK_SET, CMD_OWNER, "safeword-enable","");
             } else llMessageLinked(LINK_SET, NOTIFY, "0The safeword is current set to: '"+g_sSafeword+"'",kID);
         } else if(sChangetype == "menu"){
             if(llToLower(sChangevalue) == "access"){
@@ -316,7 +321,8 @@ UserCommand(integer iNum, string sStr, key kID) {
                 return;
             }
             llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_wearername="+sChangevalue, "");
-            llMessageLinked(LINK_SET, NOTIFY, "0The wearer's name is now set to %WEARERNAME%", kID);
+            llSleep(0.5);
+            llMessageLinked(LINK_SET, NOTIFY, "0The wearer's name is now set to %WEARERNAME% (if this is the old name, please type '/1 (prefix) name' to confirm the change went through, we may just have lagged)", kID);
         } else if(llToLower(sChangetype) == "device"){
             if(iNum!=CMD_OWNER && kID!=g_kWearer){
                 llMessageLinked(LINK_THIS,NOTIFY,"No access to device name.",kID);
@@ -330,8 +336,8 @@ UserCommand(integer iNum, string sStr, key kID) {
                     return;
                 }
                 llMessageLinked(LINK_SET, LM_SETTING_SAVE, "global_devicename="+sChangevalue,"");
-                llSleep(0.4); //To ensure the notify happens AFTER the new device name is in place.
-                llMessageLinked(LINK_SET, NOTIFY, "1The device name is now set to: %DEVICENAME%", kID);
+                llSleep(0.5); //To ensure the notify happens AFTER the new device name is in place.
+                llMessageLinked(LINK_SET, NOTIFY, "0The device name is now set to: %DEVICENAME% (if this is the old name, please type '/1 (prefix) device name' to confirm the change went through, we may just have lagged)", kID);
             }
         } else if(llToLower(sChangetype) == "allowhide"){
             if(iNum == CMD_OWNER){
@@ -728,6 +734,7 @@ state active
                     }
                 } else if(sVar == "safeword"){
                     g_sSafeword = sVal;
+                    
                 } else if(sVar == "safeworddisable"){
                     g_iSafewordDisable=1;
                 } else if(sVar == "prefix"){


### PR DESCRIPTION
Fixes for #986 and #987. This version of oc_core allows wearer to change own safeword and device name when not owner. Fix includes improvements to notifications to avoid silent authorization failures.

REQUIRES IN-WORLD TESTING before merge:
Wearer should now be able to change safeword and device name, as well as owner.
Wearer should not be able to disable safeword, only owner.
Wearer should now be notified if safeword is disabled or if device name or safeword is changed.
"(prefix) safeword" should inform wearer or owner of current safeword.
"(prefix) device name" should inform wearer or owner of current device name.
User who is neither wearer nor owner should get clear no access notification for safeword or device commands rather than silent failure.

Notes:
Refactor of safeword function in usercommand. 'Safeword off' now no longer sets safeword to 'off' before disabling, resulting in confusing "Safeword is now set to 'off'" message. Instead safeword off is clearly notified. Wearer can now set their own safeword, but only owners can disable it still. See issue # 986. Attempting to access safeword without permission now gives no access response. 
Provide no access notification for device name, and allow non-owner wearer to name. Notify wearer as well when another person changes device name. See issue # 987