### PR TITLE
Fix strict leash removing exception

### DIFF
--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -1,10 +1,16 @@
-// This file is part of OpenCollar.
-// Copyright (c) 2008 - 2016 Nandana Singh, Lulu Pink, Garvin Twine,    
-// Joy Stipe, Cleo Collins, Satomi Ahn, Master Starship, Toy Wylie,    
-// Kaori Gray, Sei Lisa, Wendy Starfall, littlemousy, Romka Swallowtail,  
-// Sumi Perl, Karo Weirsider, Kurt Burleigh, Marissa Mistwallow et al.   
-// Licensed under the GPLv2.  See LICENSE for full details. 
-string g_sScriptVersion = "8.1";
+/* This file is part of OpenCollar.
+ Copyright (c) 2008 - 2016 Nandana Singh, Lulu Pink, Garvin Twine,    
+ Joy Stipe, Cleo Collins, Satomi Ahn, Master Starship, Toy Wylie,    
+ Kaori Gray, Sei Lisa, Wendy Starfall, littlemousy, Romka Swallowtail,  
+ Sumi Perl, Karo Weirsider, Kurt Burleigh, Marissa Mistwallow et al.   
+ Licensed under the GPLv2.  See LICENSE for full details. 
+
+Medea (medea.destiny)
+    Nov 2023    -   Added EXC_REFRESH call after releasing strict leash
+                to ensure that exceptions that should be in place get 
+                restored.
+*/
+string g_sScriptVersion = "8.3";
 integer LINK_CMD_DEBUG=1999;
 
 // ------ TOKEN DEFINITIONS ------
@@ -52,6 +58,7 @@ integer RLV_CMD = 6000;
 
 integer RLV_OFF = 6100;
 integer RLV_ON = 6101;
+integer EXC_REFRESH=6200; // send to request exceptions are refreshed.
 
 integer LEASH_START_MOVEMENT = 6200;
 integer LEASH_END_MOVEMENT = 6201;
@@ -220,6 +227,8 @@ ApplyRestrictions() {
     }
     //Debug("Releasing restrictions");
     llMessageLinked(LINK_SET, RLV_CMD, "clear", "realleash");     //release all restrictions
+    llSleep(1);
+    if(g_iStrictModeOn) llMessageLinked(LINK_SET,EXC_REFRESH,"","");
 }
 key g_kPassLeashFrom;
 list g_lPasslPoints;

--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -8,7 +8,7 @@
 Medea (medea.destiny)
     Nov 2023    -   Added EXC_REFRESH call after releasing strict leash
                 to ensure that exceptions that should be in place get 
-                restored.
+                restored. issue #1008
 */
 string g_sScriptVersion = "8.3";
 integer LINK_CMD_DEBUG=1999;

--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -12,8 +12,10 @@ Medea (medea.destiny)
                 restored. issue #1008
 Nikki Larima 
     Nov 2023    - Remove processing of "runaway" command string, handled by CMD_SATEWORD
-                  implemented Yosty7b3's menu streamlining, see pr#963                  
-                
+                  implemented Yosty7b3's menu streamlining, see pr#963    
+
+Licensed under the GPLv2.  See LICENSE for full details. 
+https://github.com/OpenCollarTeam/OpenCollar               
 */
 
 string g_sScriptVersion = "8.3";

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -181,18 +181,12 @@ list g_lMuffleReplace = [
 
 integer g_iMuffleListener;
 
-/*string strReplace(string str, string search, string replace) 
-{
-    return llDumpList2String(llParseStringKeepNulls((str = "") + str, [search], []), replace);
-}*/
-
 string MuffleText(string sText)
 {
     integer i;
     for (i=0; i<llGetListLength(g_lMuffleReplace);i+=2)
     {
         sText = llDumpList2String(llParseStringKeepNulls(sText,llList2List(g_lMuffleReplace,i,i),[]),llList2String(g_lMuffleReplace,i+1));
-        //sText = strReplace(sText, llList2String(g_lMuffleReplace,i),llList2String(g_lMuffleReplace,i+1));
     }
     return sText;
 }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -46,7 +46,14 @@ Medea Destiny -
                     settings to be restored to defaults if trigged before settings are received.
                     (fixes #740, #720, #719)
     Aug2022     -   Fix auth filtering for changing exceptions. Issue #844 & #848
- 
+    Nov 20203   -   Added EXC_REFRESH link message capability to request all exceptions are refreshed.
+                    This to fix real leash temporary exception removing permanent exception, but likely to
+                    find other uses. This is less optimal than having a way to refresh individual exceptions,
+                    or even better having this script handle multiple source exceptions the way rlv_sys handles
+                    restrictions. However that's something to consider for 9.x where linkset data can reduce 
+                    memory load, this one's already very tight. Issue #1008
+                -   folded bool() function into checkbox() function with (iValue&1) and strReplace() into
+                    MuffleText() to save memory
 Krysten Minx -
    May2022      - Added check for valid UUID when setting custom exception
 */
@@ -90,6 +97,8 @@ integer RLV_REFRESH = 6001;//RLV plugins should reinstate their restrictions upo
 integer RLV_CMD_OVERRIDE=6010; // one-shot (=force) command that will override restrictions. Only use if Auth is owner level
 integer RLV_OFF = 6100; // send to inform plugins that RLV is disabled now, no message or key needed
 integer RLV_ON = 6101; // send to inform plugins that RLV is enabled now, no message or key needed
+integer EXC_REFRESH=6200; // send to request exceptions are refreshed.
+
 
 integer DIALOG = -9000;
 integer DIALOG_RESPONSE = -9001;
@@ -111,13 +120,10 @@ key g_kWearer;
 
 string g_sCameraBackMenu="menu manage"; //for allowing the camera settings menu to be in 2 places.
 
-integer bool(integer a){
-    if(a)return TRUE;
-    else return FALSE;
-}
+
 list g_lCheckboxes=["⬜","⬛"];
 string Checkbox(integer iValue, string sLabel) {
-    return llList2String(g_lCheckboxes, bool(iValue))+" "+sLabel;
+    return llList2String(g_lCheckboxes, (iValue&1))+" "+sLabel;
 }
 
 list lRLVEx = [
@@ -158,34 +164,28 @@ integer samelist(list a, list b) //Returns TRUE if a and b are identical
 
 list g_lMuffleReplace = [
     "p" , "h",
-    "P" , "H",
     "t" , "k",
-    "T" , "K",
     "m" , "n",
-    "M" , "N",
     "o" , "e",
-    "O" , "E",
     "u" , "o",
-    "U" , "O",
     "w" , "o",
-    "W" , "O",
-    "b" , "h",
-    "B" , "H"
+    "b" , "h"
 ];
 
 integer g_iMuffleListener;
 
-string strReplace(string str, string search, string replace) 
+/*string strReplace(string str, string search, string replace) 
 {
     return llDumpList2String(llParseStringKeepNulls((str = "") + str, [search], []), replace);
-}
+}*/
 
 string MuffleText(string sText)
 {
     integer i;
     for (i=0; i<llGetListLength(g_lMuffleReplace);i+=2)
     {
-        sText = strReplace(sText, llList2String(g_lMuffleReplace,i),llList2String(g_lMuffleReplace,i+1));
+        sText = llDumpList2String(llParseStringKeepNulls(sText,llList2List(g_lMuffleReplace,i,i),[]),llList2String(g_lMuffleReplace,i+1));
+        //sText = strReplace(sText, llList2String(g_lMuffleReplace,i),llList2String(g_lMuffleReplace,i+1));
     }
     return sText;
 }
@@ -221,7 +221,7 @@ MenuExceptions(key kID, integer iAuth) {
 list g_lCustomExceptions = []; // Exception name, Exception UUID, integer bitmask
 
 MenuCustomExceptionsSelect(key kID,integer iAuth){
-    string sPrompt = "\n[Exceptions]\n\nHere are your custom exceptions that are set\n\nNOTE: For groups, there are obviously some exceptions which will do nothing as there is no support for them viewer-side. We have no way to hide options that are irrelevant.";
+    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions here\n\nNOTE: Group exceptions can be set, but not all are meaningful applies to a group.";
     Dialog(kID, sPrompt, llList2ListStrided(g_lCustomExceptions, 0,-1,3),["+ ADD", "- REM", UPMENU], 0, iAuth, "Exceptions~Custom");
 }
 
@@ -847,6 +847,8 @@ state active
             //ApplyAllExceptions(TRUE,TRUE,7,TRUE);
             SetAllExes(TRUE,EX_TYPE_OWNER|EX_TYPE_TRUSTED|EX_TYPE_CUSTOM,FALSE);
             g_iRLV = FALSE;
+        } else if(iNum==EXC_REFRESH) {
+            SetAllExes(FALSE,EX_TYPE_OWNER|EX_TYPE_TRUSTED|EX_TYPE_CUSTOM,FALSE);
         } else if (iNum == RLV_REFRESH || iNum == RLV_ON) {
             g_iRLV = TRUE;
             SetAllExes(FALSE,EX_TYPE_OWNER|EX_TYPE_TRUSTED|EX_TYPE_CUSTOM,FALSE);
@@ -886,3 +888,4 @@ state active
     }
 
 }
+

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -222,7 +222,7 @@ MenuExceptions(key kID, integer iAuth) {
 list g_lCustomExceptions = []; // Exception name, Exception UUID, integer bitmask
 
 MenuCustomExceptionsSelect(key kID,integer iAuth){
-    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions here\n\nNOTE: Group exceptions can be set, but not all are meaningful applies to a group.";
+    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions here\n\nNOTE: Group exceptions can be set, but not all are meaningful applied to a group.";
     Dialog(kID, sPrompt, llList2ListStrided(g_lCustomExceptions, 0,-1,3),["+ ADD", "- REM", UPMENU], 0, iAuth, "Exceptions~Custom");
 }
 

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -164,12 +164,19 @@ integer samelist(list a, list b) //Returns TRUE if a and b are identical
 
 list g_lMuffleReplace = [
     "p" , "h",
+    "P" , "H",
     "t" , "k",
+    "T" , "K",
     "m" , "n",
+    "M" , "N",
     "o" , "e",
+    "O" , "E",
     "u" , "o",
+    "U" , "O",
     "w" , "o",
-    "b" , "h"
+    "W" , "O",
+    "b" , "h",
+    "B" , "H"
 ];
 
 integer g_iMuffleListener;


### PR DESCRIPTION
Issue #1008 

oc_leash: Added EXC_REFRESH call after releasing strict leash to ensure that exceptions that should be in place get restored.

oc_rlvextension: added EXC_REFRESH Link message handling to trigger refresh of exceptions, for above. Also folded bool() function into Checkbox() function and strReplace into MuffleText() functions to free up memory.