### PR TITLE
upate Addon Aproval message and filtering

### DIFF
--- a/src/collar/oc_addons.lsl
+++ b/src/collar/oc_addons.lsl
@@ -17,7 +17,7 @@ KristenMynx
 Ping (pingout.duffield)
    April 2024            -  Fix at Initial Handshake to disregard any nearby rezzed collar. Ref Issue #1038
 Phidoux (taya.maruti)
-   June 2024            -   Make Aproval message targeted to help prevent AddOns mistaking aprovla from others when they have yet to be Approved. #1048    
+   June 2024            -   Make Aproval message targeted to help prevent AddOns mistaking aproval from others when they have yet to be Approved. #1048    
     
 et al.
 Licensed under the GPLv2. See LICENSE for full details.

--- a/src/collar/oc_addons.lsl
+++ b/src/collar/oc_addons.lsl
@@ -344,7 +344,7 @@ state active
                         if(AddonOwnerAuth == CMD_OWNER || AddonOwnerAuth == CMD_TRUSTED){
 
                             g_lAddons += [i, llJsonGetValue(m,["addon_name"]), llGetUnixTime(), llJsonGetValue(m,["optin"]), noMenu];
-                            SayToAddonX(i, "approved", 0, "", "");
+                            SayToAddonX(i, "approved", 0, llJsonGetValue(m,["addon_name"]), i);
                             llMessageLinked(LINK_SET, NOTIFY, "0Addon connected successfully: "+llJsonGetValue(m,["addon_name"]), g_kWearer);
                         }
                         else{

--- a/src/collar/oc_addons.lsl
+++ b/src/collar/oc_addons.lsl
@@ -16,8 +16,8 @@ KristenMynx
     Jun 2022            -   Reduce chatter more
 Ping (pingout.duffield)
    April 2024            -  Fix at Initial Handshake to disregard any nearby rezzed collar. Ref Issue #1038
-    
-    
+Phidoux (taya.maruti)
+   June 2024            -   Make Aproval message targeted to help prevent AddOns mistaking aprovla from others when they have yet to be Approved. #1048    
     
 et al.
 Licensed under the GPLv2. See LICENSE for full details.

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -4,7 +4,9 @@ This script is released public domain, unlike other OC scripts for a specific an
 -Authors Attribution-
 Aria (tiff589) - (August 2020)
 Lysea - (December 2020)
-Taya'Phidoux' (taya.maruti) - (july 2021)
+Taya'Phidoux' (taya.maruti)
+    (july 2021)
+    (June 2024)        -    Add filter to prevent addons confusing aproval message meant for other addons. #1048
 */
 
 integer API_CHANNEL = 0x60b97b5e;
@@ -156,7 +158,7 @@ default
     
     listen(integer channel, string name, key id, string msg){
         string sPacketType = llJsonGetValue(msg, ["pkt_type"]);
-        if (sPacketType == "approved" && g_kCollar == NULL_KEY)
+        if (sPacketType == "approved" && (msg == g_sAddon || (key)llJsonGetValue(msg,["kID"]) == llGetKey()) &&g_kCollar == NULL_KEY)
         {
             // This signal, indicates the collar has approved the addon and that communication requests will be responded to if the requests are valid collar LMs.
             g_kCollar = id;

--- a/src/spares/oc_addon_template.lsl
+++ b/src/spares/oc_addon_template.lsl
@@ -158,7 +158,7 @@ default
     
     listen(integer channel, string name, key id, string msg){
         string sPacketType = llJsonGetValue(msg, ["pkt_type"]);
-        if (sPacketType == "approved" && (msg == g_sAddon || (key)llJsonGetValue(msg,["kID"]) == llGetKey()) &&g_kCollar == NULL_KEY)
+        if (sPacketType == "approved" && (llJsonGetValue(msg,["sMsg"]) == g_sAddon || (key)llJsonGetValue(msg,["kID"]) == llGetKey()) &&g_kCollar == NULL_KEY)
         {
             // This signal, indicates the collar has approved the addon and that communication requests will be responded to if the requests are valid collar LMs.
             g_kCollar = id;


### PR DESCRIPTION
Update the addon aproval message and filtering to prevent addon confusion when you have multiple addons and one is aproved but the other has yet to be approved.

This fixes an issue with multiple addons that could in some cases break their connection to the collar.
#1048 