### PR TITLE
update installer for oc_timer

### DIFF
--- a/src/installer/BUNDLE_40-Apps_OPTIONAL
+++ b/src/installer/BUNDLE_40-Apps_OPTIONAL
@@ -8,3 +8,4 @@ SCRIPT|oc_detach
 SCRIPT|oc_outfits
 SCRIPT|oc_bell
 SCRIPT|oc_folders
+SCRIPT|oc_timer


### PR DESCRIPTION
Adds oc_timer to optional bundle in installer, now we have a nice working timer again