### PR TITLE
oc_bookmarks fix broken links

### DIFF
--- a/src/collar/oc_bookmarks.lsl
+++ b/src/collar/oc_bookmarks.lsl
@@ -7,7 +7,7 @@
 /*
 Medea Destiny -
     Dec 2021   -   Provided clickable SLURL feedback to command issuer
-
+    Aug 2024   -   Fix for above, escaping sim name with spaces, issue #1026
 */
 
 string g_sScriptVersion = "8.2";

--- a/src/collar/oc_bookmarks.lsl
+++ b/src/collar/oc_bookmarks.lsl
@@ -354,7 +354,7 @@ TeleportTo(string sStr,key kIssuer) {  //take a string in region (x,y,z) format,
         llMapDestination(sRegion, g_vLocalPos, ZERO_VECTOR);
     else  //We've got RLV, let's use it
         g_kRequestHandle = llRequestSimulatorData(sRegion, DATA_SIM_POS);
-        llRegionSayTo(kIssuer,0,"Sending "+llGetDisplayName(g_kWearer)+" to http://maps.secondlife.com/secondlife/"+sRegion+"/"+(string)((integer)g_vLocalPos.x) + "/"+(string)((integer)g_vLocalPos.y)+"/"+(string)((integer)g_vLocalPos.z)+".");   
+        llRegionSayTo(kIssuer,0,"Sending "+llGetDisplayName(g_kWearer)+" to http://maps.secondlife.com/secondlife/"+llEscapeURL(sRegion)+"/"+(string)((integer)g_vLocalPos.x) + "/"+(string)((integer)g_vLocalPos.y)+"/"+(string)((integer)g_vLocalPos.z)+".");   
     
    
 }


### PR DESCRIPTION
Escapes region names in SLURL reported to collar user when teleporting collar wearer. Unescaped URLs were breaking the slurl if the sim has a multi-word name, by simply escaping the sim name with llEscape we get a functional SLURL.