### PR TITLE
Fix typo in timer

### DIFF
--- a/src/Apps/oc_timer.lsl
+++ b/src/Apps/oc_timer.lsl
@@ -230,7 +230,7 @@ UserCommand(integer iAuth, string sCmd, key kAv)
             sVal=(string)llList2List(lParams,2,-1);
             string sVal=(string)llList2List(lParams,2,-1);
             integer ti;
-            list t=llParseString2List(sVal,[","],["hourse","hrs","hr","hs","h"]);
+            list t=llParseString2List(sVal,[","],["hours","hrs","hr","hs","h"]);
             if(llGetListLength(t)>1)
             {
                 ti+=(integer)llList2String(t,0)*3600;


### PR DESCRIPTION
parsing of chat time setting had a typo for "hours" as "hourse". Fixes that. No need for testing.