### PR TITLE
typo fix 

### DIFF
--- a/src/collar/oc_api.lsl
+++ b/src/collar/oc_api.lsl
@@ -796,7 +796,7 @@ state active
                         llMessageLinked(LINK_SET, LM_SETTING_SAVE, "AUTH_runaway=0", "origin"); 
                         llMessageLinked(LINK_SET, TIMEOUT_REGISTER, "2", "spring_access:"+(string)g_kDenyRunawayRequester);
                     } else if (sMsg=="Deny"){
-                        llMessageLinked(LINK_SET, NOTIFY, "Wearer has DENIED switching off runaway.",g_kDenyRunawayRequester);
+                        llMessageLinked(LINK_SET, NOTIFY, "0Wearer has DENIED switching off runaway.",g_kDenyRunawayRequester);
                         llMessageLinked(LINK_SET, TIMEOUT_REGISTER, "2", "spring_access:"+(string)g_kDenyRunawayRequester);
                     }             
                 }


### PR DESCRIPTION
Typo fix reported by Trinkitz in world: "Trink's 8.3 beta test collar: earer has DENIED switching off runaway." - "earer" should be "wearer" .

This is a common bug with NOTIFY messages. First character should always be a 0 (regular message to targeted user) or 1 (message to both targeted user and wearer) otherwise the first letter of the sentence gets dropped. At some point we should fix dialog to just not strip the first character if it isn't a 0 or 1. 