### PR TITLE
Update oc_particle.lsl

### DIFF
--- a/src/collar/oc_particle.lsl
+++ b/src/collar/oc_particle.lsl
@@ -806,7 +806,7 @@ state active
                     }  else if (sLGCMD == "ping") {
                         llWhisper( g_iChan_LOCKGUARD, "lockguard " + (string)llGetOwner() + " " +  sLGPoint + " okay" );
                     }  else {
-                        llWhisper(0, "Unknown LockGuard command: "+sLGCMD);
+                        //llWhisper(0, "Unknown LockGuard command: "+sLGCMD);
                     }   
                 }
                 if (iIsLinking) {


### PR DESCRIPTION
Random error message being chatted in local. We have various debug messages coming through in the oc_particle script for lockguard commands being whispered, with the llSay commands normally commented out. I assume this is just a miss on commenting out a debug message, so commenting this one out. There's no real value in this error message other than debug

I'm slightly concerned that the lockguard command was being processed at all, because as far as I can see the collar was reacting to a lockguard message from someone else's attachment. Shouldn't this be filtered on avatar target @NikkiLacrima ? However this will avoid random spamming of the message