### PR TITLE
OBJECT_TEMP_ATTACHED rejection in oc_API for interface channel

### DIFF
--- a/src/collar/oc_api.lsl
+++ b/src/collar/oc_api.lsl
@@ -529,6 +529,7 @@ state active
                 return;
             }
             else {
+                if(llList2Integer(llGetObjectDetails(i,[OBJECT_TEMP_ATTACHED])==1) return;
                 key kAuthKey=llGetOwnerKey(i);
                 integer iAuth=CalcAuth(kAuthKey);
                 if(llGetSubString(m,0,6)=="authas:"){ //messages prefixed authas:(key)=(cmd) will use the auth level of key if LOWER than object owner auth.

--- a/src/collar/oc_api.lsl
+++ b/src/collar/oc_api.lsl
@@ -46,7 +46,8 @@ Medea (Medea Destiny)
                     the only thing the wearer can do is safeword, which will deactivate it.
                     Any attempt to trigger a menu/command will send the AUTH_WEARERLOCKOUT
                     Link message. Any script setting a wearer lockout should respond to this with a status
-                    update.                
+                    update.  
+     *Spet 2024  -  Added rejection of interface channel commands from temp-attached objects
                            
 Yosty7b3        
     *Oct 2021   -   Remove unused StrideOfList() function.

--- a/src/collar/oc_api.lsl
+++ b/src/collar/oc_api.lsl
@@ -529,7 +529,7 @@ state active
                 return;
             }
             else {
-                if(llList2Integer(llGetObjectDetails(i,[OBJECT_TEMP_ATTACHED])==1) return;
+                if(llList2Integer(llGetObjectDetails(i,[OBJECT_TEMP_ATTACHED]),0)==1) return;
                 key kAuthKey=llGetOwnerKey(i);
                 integer iAuth=CalcAuth(kAuthKey);
                 if(llGetSubString(m,0,6)=="authas:"){ //messages prefixed authas:(key)=(cmd) will use the auth level of key if LOWER than object owner auth.

--- a/src/collar/oc_api.lsl
+++ b/src/collar/oc_api.lsl
@@ -47,7 +47,7 @@ Medea (Medea Destiny)
                     Any attempt to trigger a menu/command will send the AUTH_WEARERLOCKOUT
                     Link message. Any script setting a wearer lockout should respond to this with a status
                     update.  
-     *Spet 2024  -  Added rejection of interface channel commands from temp-attached objects
+     *Sept 2024  -  Added rejection of interface channel commands from temp-attached objects
                            
 Yosty7b3        
     *Oct 2021   -   Remove unused StrideOfList() function.


### PR DESCRIPTION
Scottie Muircastle just pointed out to me a potential vulnerability in the object interface function. As temporary attachments become "owned" by the wearer, in theory people could use a temporary attachment that's attached as a furniture prop to send OC command with the collar wearer's auth. This was an issue previously with RLVa rejecting RLV commands from temp attachments as it's a potential vector for bypassing auth.

I've chucked in an extra line to simply reject arbitary commands from temp attachments which should resolve this. We should consider having this as a user setting or similar. I haven't had time to test this as yet but as it's a potential security flaw we need to consider this as a security patch for 8.3