### PR TITLE
Reduce oc_rlvextension.lsl memory usage

### DIFF
--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -162,31 +162,19 @@ integer samelist(list a, list b) //Returns TRUE if a and b are identical
     return !llListFindList(llListSort(a,1,1),llListSort(b,1,1));
 }
 
-list g_lMuffleReplace = [
-    "p" , "h",
-    "P" , "H",
-    "t" , "k",
-    "T" , "K",
-    "m" , "n",
-    "M" , "N",
-    "o" , "e",
-    "O" , "E",
-    "u" , "o",
-    "U" , "O",
-    "w" , "o",
-    "W" , "O",
-    "b" , "h",
-    "B" , "H"
-];
+string g_sMuffleReplace =
+    "p:h|P:H|t:k|T:K|m:n|M:N|o:e|O:E|u:o|U:O|w:o|W:O|b:h|B:H";
 
 integer g_iMuffleListener;
 
 string MuffleText(string sText)
 {
+    list lPairs = llParseString2List(g_sMuffleReplace, ["|"], []);
     integer i;
-    for (i=0; i<llGetListLength(g_lMuffleReplace);i+=2)
+    for (i = 0; i < llGetListLength(lPairs); ++i)
     {
-        sText = llDumpList2String(llParseStringKeepNulls(sText,llList2List(g_lMuffleReplace,i,i),[]),llList2String(g_lMuffleReplace,i+1));
+        list lPair = llParseString2List(llList2String(lPairs, i), [":"], []);
+        sText = llDumpList2String(llParseStringKeepNulls(sText, [llList2String(lPair, 0)], []), llList2String(lPair, 1));
     }
     return sText;
 }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -180,13 +180,7 @@ string MuffleText(string sText)
     {
         string from = llGetSubString(g_sMuffleReplace, i, i);
         string to = llGetSubString(g_sMuffleReplace, i+1, i+1);
-        integer pos = llSubStringIndex(sText, from);
-        while (pos != -1)
-        {
-            sText = llDeleteSubString(sText, pos, pos);
-            sText = llInsertString(sText, pos, to);
-            pos = llSubStringIndex(sText, from);
-        }
+        sText = llReplaceSubString( sText, from, to, 0 );
     }
     return sText;
 }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -204,13 +204,13 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
 }
 
 MenuExceptions(key kID, integer iAuth) {
-    string sPrompt = "\n[Exceptions]\n \nSet RLV restrictions for bypass. OWNER and TRUSTED apply to all with that role. CUSTOM are set per person.";
+    string sPrompt = "\n[Exceptions]\n \nSet exceptions to the restrictions for RLV commands.\nOWNER and TRUSTED menus set the exceptions for all people with that authorization level, CUSTOM allows you to set different exceptions for specific people.";
     Dialog(kID, sPrompt, ["Owner","Trusted","Custom"], [UPMENU], 0, iAuth, "Exceptions~Main");
 }
 list g_lCustomExceptions = []; // Exception name, Exception UUID, integer bitmask
 
 MenuCustomExceptionsSelect(key kID,integer iAuth){
-    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions\n\nNOTE: Some group exceptions don't affect some groups.";
+    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions here\n\nNOTE: Group exceptions can be set, but not all are meaningful applied to a group.";
     Dialog(kID, sPrompt, llList2ListStrided(g_lCustomExceptions, 0,-1,3),["+ ADD", "- REM", UPMENU], 0, iAuth, "Exceptions~Custom");
 }
 
@@ -247,7 +247,7 @@ MenuSetExceptions(key kID, integer iAuth, string sTarget){
     if(sTarget=="Owner") menutext+="OWNERS";
     else if(sTarget=="Trusted") menutext+="TRUSTED PEOPLE";
     else menutext+="'"+g_sTmpExceptionName+"'";
-    menutext+=" from being impacted by restrictions. Wearer can always:\n *IM - send them IMs\n *RcvIM - Receive their IMs\n *RcvChat - Hear their chat\n *RcvEmote - See their emotes\n *Lure - Receive their TP offers\n *StartIM - Start IM conversations with them\n *Force TP - When on, automatically accept thier teleports";
+    menutext+=" from being impacted by restrictions. Wearer can always:\n *IM - send them IMs\n *RcvIM - Receive their IMs\n *RcvChat - Hear their chat\n *RcvEmote - See their emotes\n *Lure - Receive their TP offers\n *StartIM - Start IM conversations with them\n *Force TP - When on, automatically accept their teleports";
     
     Dialog(kID, menutext, lButtons, [UPMENU], 0, iAuth, "Exceptions~Set");
 }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -436,9 +436,10 @@ UserCommand(integer iNum, string sStr, key kID) {
         }    
     } 
     else if(llSubStringIndex(sStr,"sit") && llSubStringIndex(sStr,"rlvex")) return;
-    else { 
-        string sChangetype = llList2String(llParseString2List(sStr, [" "], []),0);
-        string sChangekey = llList2String(llParseString2List(sStr, [" "], []),1);
+    else {
+        list lCmd = llParseString2List(sStr, [" "], []);
+        string sChangetype = llList2String(lCmd,0);
+        string sChangekey = llList2String(lCmd,1);
         if (sChangetype == "sit") {
             if ((sChangekey == "[unsit]" || sChangekey == "unsit")) {
                 if(iNum> g_iLastSitAuth ) {
@@ -465,8 +466,8 @@ UserCommand(integer iNum, string sStr, key kID) {
             }
         } else if(sChangetype == "rlvex" && iNum == CMD_OWNER){
             if(sChangekey == "modify"){
-                string sChangeArg1 = llToLower(llList2String(llParseString2List(sStr, [" "],[]), 2));
-                string sChangeArg2 = llToLower(llList2String(llParseString2List(sStr,[" "],[]), 3));
+                string sChangeArg1 = llToLower(llList2String(lCmd, 2));
+                string sChangeArg2 = llToLower(llList2String(lCmd, 3));
                 if(sChangeArg1 == "owner"){
                     g_iOwnerEx = (integer)sChangeArg2;
                     llMessageLinked(LINK_SET, NOTIFY, "0Owner exceptions modified", kID);
@@ -477,7 +478,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                     SetAllExes(FALSE,EX_TYPE_TRUSTED,TRUE);
                 } else {
                     // modify custom exception. arg1 = name, arg2 = uuid, arg3 = bitmask. remove old if exists, replace with new. including updating the exception uuid
-                    string sChangeArg3 = llToLower(llList2String(llParseString2List(sStr,[" "],[]),4));
+                    string sChangeArg3 = llToLower(llList2String(lCmd,4));
                     if(sChangeArg1==""||sChangeArg2==""||sChangeArg3==""){
                         llMessageLinked(LINK_SET, NOTIFY, "0Invalid amount of arguments for modifying a custom exception", kID);
                         return;

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -150,12 +150,10 @@ list g_lTempOwners = [];
 integer g_iOwnerEx = 127;
 integer g_iTrustedEx = 95;
 
-list g_lMenuIDs;
 //integer TIMEOUT_READY = 30497;
 integer TIMEOUT_REGISTER = 30498;
 integer TIMEOUT_FIRED = 30499;
 //list g_lSettingsReqs = [];
-integer g_iMenuStride;
 integer g_iLocked=FALSE;
 
 //list g_lStrangerEx = [];
@@ -199,14 +197,10 @@ SetMuffle(integer bEnable)
 }
 
 Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPage, integer iAuth, string sName) {
-    key kMenuID = llGenerateKey();
+    string kMenuID = sName + "~" + llGetScriptName();
     if (sName == "Restrictions~sensor" || sName == "find")
-    llMessageLinked(LINK_SET, DIALOG_SENSOR, (string)kID +"|"+sPrompt+"|0|``"+(string)(SCRIPTED|PASSIVE)+"`20`"+(string)PI+"`"+llDumpList2String(lUtilityButtons,"`")+"|"+llDumpList2String(lChoices,"`")+"|" + (string)iAuth, kMenuID);
-    else llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, kMenuID);
-
-    integer iIndex = llListFindList(g_lMenuIDs, [kID]);
-    if (~iIndex) g_lMenuIDs = llListReplaceList(g_lMenuIDs, [kID, kMenuID, sName], iIndex, iIndex + g_iMenuStride - 1);
-    else g_lMenuIDs += [kID, kMenuID, sName];
+        llMessageLinked(LINK_SET, DIALOG_SENSOR, (string)kID +"|"+sPrompt+"|0|``"+(string)(SCRIPTED|PASSIVE)+"`20`"+(string)PI+"`"+llDumpList2String(lUtilityButtons,"`")+"|"+llDumpList2String(lChoices,"`")+"|" + (string)iAuth, (key)kMenuID);
+    else llMessageLinked(LINK_SET, DIALOG, (string)kID + "|" + sPrompt + "|" + (string)iPage + "|" + llDumpList2String(lChoices, "`") + "|" + llDumpList2String(lUtilityButtons, "`") + "|" + (string)iAuth, (key)kMenuID);
 }
 
 MenuExceptions(key kID, integer iAuth) {
@@ -553,10 +547,9 @@ state active
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu1,""); // Register menu "Force Sit"
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu2,""); // Register Exceptions Menu
         } else if(iNum == DIALOG_RESPONSE){
-            integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
-            if(iMenuIndex!=-1){
-                string sMenu = llList2String(g_lMenuIDs, iMenuIndex+1);
-                g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex-1, iMenuIndex-2+g_iMenuStride);
+            integer iPos = llSubStringIndex(kID, "~"+llGetScriptName());
+            if(iPos>0){
+                string sMenu = llGetSubString(kID,0,iPos-1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -60,7 +60,8 @@ Krysten Minx -
     May 2022    -   Added check for valid UUID when setting custom exception
 
 chew -
-    Jun 2025    -   Refactor MuffleText, shorten some language strings - reduced memory footprint
+    Jun 2025    -   Reduced memory footprint: Refactor MuffleText, refactor Dialog, reduce redundant
+                    list calls in MenuSetValue, shorten some language strings
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -204,24 +204,24 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
 }
 
 MenuExceptions(key kID, integer iAuth) {
-    string sPrompt = "\n[Exceptions]\n \nSet which RLV restrictions to bypass. OWNER and TRUSTED apply to all with that role. CUSTOM lets you set them per person.";
+    string sPrompt = "\n[Exceptions]\n \nSet RLV restrictions for bypass. OWNER and TRUSTED apply to all with that role. CUSTOM are set per person.";
     Dialog(kID, sPrompt, ["Owner","Trusted","Custom"], [UPMENU], 0, iAuth, "Exceptions~Main");
 }
 list g_lCustomExceptions = []; // Exception name, Exception UUID, integer bitmask
 
 MenuCustomExceptionsSelect(key kID,integer iAuth){
-    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions\n\nNOTE: Some group exceptions may not affect some groups.";
+    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions\n\nNOTE: Some group exceptions don't affect some groups.";
     Dialog(kID, sPrompt, llList2ListStrided(g_lCustomExceptions, 0,-1,3),["+ ADD", "- REM", UPMENU], 0, iAuth, "Exceptions~Custom");
 }
 
 MenuCustomExceptionsRem(key kID, integer iAuth){
-    string sPrompt = "\n[Exceptions]\n\nWhich custom exception shoudl be removed?";
+    string sPrompt = "\n[Exceptions]\n\nWhich custom exception should be removed?";
     Dialog(kID, sPrompt, llList2ListStrided(g_lCustomExceptions, 0, -1, 3), [UPMENU], 0, iAuth, "Exceptions~CustomRem");
 }
 
 string g_sTmpExceptionName;
 MenuAddCustomExceptionName(key kID, integer iAuth){
-    Dialog(kID,"Name the custom exception", [],[],0,iAuth,"Exceptions~AddCustomName");
+    Dialog(kID,"Custom exception name?", [],[],0,iAuth,"Exceptions~AddCustomName");
 }
 
 key g_kTmpExceptionID;
@@ -488,7 +488,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                     sExceptionMasks += llList2String(lRLVEx,ix)+" = "+llList2String(lRLVEx,ix+2)+", ";
                 }
                 // list all possible bitmasks
-                llMessageLinked(LINK_SET, NOTIFY, "0Exceptions use a bitmask. Allowed values: "+sExceptionMasks+". Add selected values for the bitmask. Max is 127.", kID);
+                llMessageLinked(LINK_SET, NOTIFY, "0Exceptions use a bitmask. Allowed values: "+sExceptionMasks+". Add selected values for the bitmask. Max bitmask is 127.", kID);
             } else if(sChangekey == "help"){
                 llMessageLinked(LINK_SET, NOTIFY, "0Commands: listmasks, modify, listcustom\n\nmodify takes 2-3 arguments.\nmodify owner [newBitmask]\nmodify trust [newMask]\nmodify [customExceptionName(no spaces)] [customExceptionUUID] [bitmask]", kID);
             } else if(sChangekey == "listcustom"){

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -3,8 +3,9 @@
 This file is part of OpenCollar.
 Copyright (c) 2018 - 2019 Tashia Redrose, Silkie Sabra, lillith xue, Medea Destiny, Nirea Mercury et al.                           
 Licensed under the GPLv2.  See LICENSE for full details. 
+
 Medea Destiny -
-    Sept 2021   -   Moved Exceptions menu into RLV as a main directory, and folded Menu Settings into
+    Sep 2021    -   Moved Exceptions menu into RLV as a main directory, and folded Menu Settings into
                     RLVSuite menu customize
                 -   Refactored Exceptions setting with new functions to allow Exceptions to be applied
                     individually (setUserExceptions() function), replaced ApplyAllExceptions() function
@@ -40,13 +41,13 @@ Medea Destiny -
                     automatically for owners. 
                 -   Added explanatory text to exceptions and force sit menus
                 -   Renamed Refuse TP to Force TP to reflect what the button actually does.                  
-    Dec2021     -   Fixed filtering of unsit - > sit unsit for chat command and remote (issue #703 )
+    Dec 2021    -   Fixed filtering of unsit - > sit unsit for chat command and remote (issue #703 )
                 -   Fix to disengaging strict sit when disabled via menu when already sitting.
-    Feb2022     -   SetAllExes triggered on RLV_REFRESH / RLV_ON was saving values, causing exception
+    Feb 2022    -   SetAllExes triggered on RLV_REFRESH / RLV_ON was saving values, causing exception
                     settings to be restored to defaults if trigged before settings are received.
                     (fixes #740, #720, #719)
-    Aug2022     -   Fix auth filtering for changing exceptions. Issue #844 & #848
-    Nov 2023   -   Added EXC_REFRESH link message capability to request all exceptions are refreshed.
+    Aug 2022    -   Fix auth filtering for changing exceptions. Issue #844 & #848
+    Nov 2023    -   Added EXC_REFRESH link message capability to request all exceptions are refreshed.
                     This to fix real leash temporary exception removing permanent exception, but likely to
                     find other uses. This is less optimal than having a way to refresh individual exceptions,
                     or even better having this script handle multiple source exceptions the way rlv_sys handles
@@ -54,8 +55,12 @@ Medea Destiny -
                     memory load, this one's already very tight. Issue #1008
                 -   folded bool() function into checkbox() function with (iValue&1) and strReplace() into
                     MuffleText() to save memory
+
 Krysten Minx -
-   May2022      - Added check for valid UUID when setting custom exception
+    May 2022    -   Added check for valid UUID when setting custom exception
+
+chew -
+    Jun 2025    -   Refactor MuffleText, shorten some language strings - reduced memory footprint
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -204,29 +204,29 @@ Dialog(key kID, string sPrompt, list lChoices, list lUtilityButtons, integer iPa
 }
 
 MenuExceptions(key kID, integer iAuth) {
-    string sPrompt = "\n[Exceptions]\n \nSet exceptions to the restrictions for RLV commands.\nOWNER and TRUSTED menus set the exceptions for all people with that authorization level, CUSTOM allows you to set different exceptions for specific people.";
+    string sPrompt = "\n[Exceptions]\n \nSet which RLV restrictions to bypass. OWNER and TRUSTED apply to all with that role. CUSTOM lets you set them per person.";
     Dialog(kID, sPrompt, ["Owner","Trusted","Custom"], [UPMENU], 0, iAuth, "Exceptions~Main");
 }
 list g_lCustomExceptions = []; // Exception name, Exception UUID, integer bitmask
 
 MenuCustomExceptionsSelect(key kID,integer iAuth){
-    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions here\n\nNOTE: Group exceptions can be set, but not all are meaningful applied to a group.";
+    string sPrompt = "\n[Exceptions]\n\nSet custom exceptions\n\nNOTE: Some group exceptions may not affect some groups.";
     Dialog(kID, sPrompt, llList2ListStrided(g_lCustomExceptions, 0,-1,3),["+ ADD", "- REM", UPMENU], 0, iAuth, "Exceptions~Custom");
 }
 
 MenuCustomExceptionsRem(key kID, integer iAuth){
-    string sPrompt = "\n[Exceptions]\n\nWhich custom exception do you want to remove?";
+    string sPrompt = "\n[Exceptions]\n\nWhich custom exception shoudl be removed?";
     Dialog(kID, sPrompt, llList2ListStrided(g_lCustomExceptions, 0, -1, 3), [UPMENU], 0, iAuth, "Exceptions~CustomRem");
 }
 
 string g_sTmpExceptionName;
 MenuAddCustomExceptionName(key kID, integer iAuth){
-    Dialog(kID,"What should we call this custom exception?", [],[],0,iAuth,"Exceptions~AddCustomName");
+    Dialog(kID,"Name the custom exception", [],[],0,iAuth,"Exceptions~AddCustomName");
 }
 
 key g_kTmpExceptionID;
 MenuAddCustomExceptionID(key kID, integer iAuth){
-    Dialog(kID, "What UUID does this exception affect?", [],[],0,iAuth,"Exceptions~AddCustomID");
+    Dialog(kID, "Which UUID should this affect?", [],[],0,iAuth,"Exceptions~AddCustomID");
 }
 
 MenuSetExceptions(key kID, integer iAuth, string sTarget){
@@ -243,18 +243,18 @@ MenuSetExceptions(key kID, integer iAuth, string sTarget){
     for (i=0; i<llGetListLength(lRLVEx);i=i+3) {
         lButtons += Checkbox((iExMask&llList2Integer(lRLVEx,i+2)), llList2String(lRLVEx,i));
     }
-    string menutext="  --EXCEPTIONS Menu--\nThese options exclude ";
+    string menutext="  --EXCEPTIONS--\nThese exclude ";
     if(sTarget=="Owner") menutext+="OWNERS";
     else if(sTarget=="Trusted") menutext+="TRUSTED PEOPLE";
     else menutext+="'"+g_sTmpExceptionName+"'";
-    menutext+=" from being impacted by wearer's restrictions. Even if restricted, wearer can:\n *IM - talk in IMs with them.\n *RcvIM - Receive IMs from them.\n *RcvChat - Hear their public chat.\n *RcvEmote - See their public emotes\n *Lure - Receive TP offers from them.\n *StartIM - Start a new IM conversation with them.\n *Force TP - When on, wearer is automatically teleported on receiving a TP offer from them.";
+    menutext+=" from being impacted by restrictions. Wearer can always:\n *IM - send them IMs\n *RcvIM - Receive their IMs\n *RcvChat - Hear their chat\n *RcvEmote - See their emotes\n *Lure - Receive their TP offers\n *StartIM - Start IM conversations with them\n *Force TP - When on, automatically accept thier teleports";
     
     Dialog(kID, menutext, lButtons, [UPMENU], 0, iAuth, "Exceptions~Set");
 }
 
 MenuForceSit(key kID, integer iAuth) {
     
-    Dialog(kID, "\nSelect a place to force sit the wearer on it, or [UNSIT] to force them to stand up. \nWearer may stand after being force sat unless STRICT SIT is active. When it's active, they are forbidden from standing ONLY when force sat from this menu, and if force sat will need to be released with [UNSIT].\n", [Checkbox(g_iStrictSit, "Strict Sit"), UPMENU, "[UNSIT]"], [], 0, iAuth, "Restrictions~sensor");
+    Dialog(kID, "\nSelect a place to force sit. Use [UNSIT] to stand up. \nSTRICT SIT prevents wearer from standing during a forced sit.\n", [Checkbox(g_iStrictSit, "Strict Sit"), UPMENU, "[UNSIT]"], [], 0, iAuth, "Restrictions~sensor");
 }
 
 MenuCamera(key kID, integer iAuth){
@@ -265,7 +265,7 @@ MenuChat(key kID, integer iAuth){
     string sBtn;
     sBtn = Checkbox(g_bMuffle, "Muffle");
     
-    Dialog(kID, "Selecting MUFFLE will cause speech to be garbled rather than completely blocked with the TALK restrictions preset is activated.", [sBtn], [UPMENU], 0, iAuth, "Settings~Chat");
+    Dialog(kID, "MUFFLE garbles speech instead of blocking it when TALK restrictions are on.", [sBtn], [UPMENU], 0, iAuth, "Settings~Chat");
 }
 
 MenuSetValue(key kID, integer iAuth, string sValueName) {
@@ -413,13 +413,13 @@ UserCommand(integer iNum, string sStr, key kID) {
         if(sStr=="menu managecamera2") g_sCameraBackMenu="menu category Camera";
         if (iNum < CMD_EVERYONE) MenuCamera(kID,iNum);
         else {
-            llMessageLinked(LINK_SET, NOTIFY, "0"+"%NOACCESS% to changing camera settings", kID);
+            llMessageLinked(LINK_SET, NOTIFY, "0"+"%NOACCESS% to change camera settings", kID);
             llMessageLinked(LINK_SET, iNum,g_sCameraBackMenu, kID);
         }
     }else if( sStr=="menu managechat") {
         if (iNum < CMD_EVERYONE) MenuChat(kID,iNum);
         else {
-            llMessageLinked(LINK_SET, NOTIFY, "0"+"%NOACCESS% to changing muffle settings", kID);
+            llMessageLinked(LINK_SET, NOTIFY, "0"+"%NOACCESS% to change muffle settings", kID);
             llMessageLinked(LINK_SET, iNum, "menu [Manage]", kID);
         }    
     } 
@@ -431,7 +431,7 @@ UserCommand(integer iNum, string sStr, key kID) {
         if (sChangetype == "sit") {
             if ((sChangekey == "[unsit]" || sChangekey == "unsit")) {
                 if(iNum> g_iLastSitAuth ) {
-                    llMessageLinked(LINK_SET,NOTIFY,"0Cannot unsit from a force sit set by someone with higher auth level.",kID);
+                    llMessageLinked(LINK_SET,NOTIFY,"0Cannot unsit from a sit forced by a higher auth level.",kID);
                     return;
                 }
                 if(g_iStrictSit){
@@ -443,7 +443,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                 g_iLastSitAuth = 599;
             } else {
                 if(iNum > g_iLastSitAuth){
-                    llMessageLinked(LINK_SET, NOTIFY, "0Cannot override sit forced by someone with higher auth level.", kID);
+                    llMessageLinked(LINK_SET, NOTIFY, "0Cannot override sit forced by a higher auth level.", kID);
                     return;
                 }
                 g_iLastSitAuth = iNum;
@@ -458,17 +458,17 @@ UserCommand(integer iNum, string sStr, key kID) {
                 string sChangeArg2 = llToLower(llList2String(lCmd, 3));
                 if(sChangeArg1 == "owner"){
                     g_iOwnerEx = (integer)sChangeArg2;
-                    llMessageLinked(LINK_SET, NOTIFY, "0Owner exceptions modified", kID);
+                    llMessageLinked(LINK_SET, NOTIFY, "0Owner exceptions updated", kID);
                     SetAllExes(FALSE,EX_TYPE_OWNER,TRUE);
                 } else if(llGetSubString(sChangeArg1,0,4) == "trust"){
                     g_iTrustedEx = (integer)sChangeArg2;
-                    llMessageLinked(LINK_SET, NOTIFY, "0Trusted exceptions modified", kID);
+                    llMessageLinked(LINK_SET, NOTIFY, "0Trusted exceptions updated", kID);
                     SetAllExes(FALSE,EX_TYPE_TRUSTED,TRUE);
                 } else {
                     // modify custom exception. arg1 = name, arg2 = uuid, arg3 = bitmask. remove old if exists, replace with new. including updating the exception uuid
                     string sChangeArg3 = llToLower(llList2String(lCmd,4));
                     if(sChangeArg1==""||sChangeArg2==""||sChangeArg3==""){
-                        llMessageLinked(LINK_SET, NOTIFY, "0Invalid amount of arguments for modifying a custom exception", kID);
+                        llMessageLinked(LINK_SET, NOTIFY, "0Invalid argument count for custom exception", kID);
                         return;
                     }
                     integer iPosx=llListFindList(g_lCustomExceptions, [sChangeArg1]);
@@ -476,7 +476,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                         // process
                         g_lCustomExceptions = llDeleteSubList(g_lCustomExceptions, iPosx, iPosx+2);
                     }
-                    llMessageLinked(LINK_SET, NOTIFY, "0Custom exceptions modified  ("+sChangeArg1+"): "+sChangeArg2+" = "+sChangeArg3, kID);
+                    llMessageLinked(LINK_SET, NOTIFY, "0Custom exceptions updated  ("+sChangeArg1+"): "+sChangeArg2+" = "+sChangeArg3, kID);
                     g_lCustomExceptions += [sChangeArg1, sChangeArg2, (integer)sChangeArg3];
                     SetAllExes(FALSE,EX_TYPE_CUSTOM,TRUE);
                 }
@@ -488,9 +488,9 @@ UserCommand(integer iNum, string sStr, key kID) {
                     sExceptionMasks += llList2String(lRLVEx,ix)+" = "+llList2String(lRLVEx,ix+2)+", ";
                 }
                 // list all possible bitmasks
-                llMessageLinked(LINK_SET, NOTIFY, "0The exceptions all use a bitmask. The following are acceptable bitmask values: "+sExceptionMasks+". To calculate a bitmask, add the values into one larger integer for only the options you want. 127 is the max possible bitmask for exceptions", kID);
+                llMessageLinked(LINK_SET, NOTIFY, "0Exceptions use a bitmask. Allowed values: "+sExceptionMasks+". Add selected values for the bitmask. Max is 127.", kID);
             } else if(sChangekey == "help"){
-                llMessageLinked(LINK_SET, NOTIFY, "0Valid commands: listmasks, modify, listcustom\n\nmodify takes a range of 2-3 arguments.\nmodify owner [newBitmask]\nmodify trust [newMask]\nmodify [customExceptionName(no spaces)] [customExceptionUUID] [bitmask]", kID);
+                llMessageLinked(LINK_SET, NOTIFY, "0Commands: listmasks, modify, listcustom\n\nmodify takes 2-3 arguments.\nmodify owner [newBitmask]\nmodify trust [newMask]\nmodify [customExceptionName(no spaces)] [customExceptionUUID] [bitmask]", kID);
             } else if(sChangekey == "listcustom"){
                 integer ix=0;
                 string sCustom;
@@ -561,7 +561,7 @@ state active
                     if(sMsg == UPMENU)  llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     else if (iAuth!=CMD_OWNER)
                     {
-                        llMessageLinked(LINK_SET,NOTIFY,"0No access to changing exceptions!", kAv);
+                        llMessageLinked(LINK_SET,NOTIFY,"0No access to change exceptions", kAv);
                         llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                         return;
                     }
@@ -636,7 +636,7 @@ state active
                 else if (sMenu == "Restrictions~sensor") {
                     if(sMsg == Checkbox(g_iStrictSit,"Strict Sit")){
                         if(iAuth != CMD_OWNER) {
-                            llMessageLinked(LINK_SET, NOTIFY, "0%NOACCESS% to setting Strict Sit", kAv);
+                            llMessageLinked(LINK_SET, NOTIFY, "0%NOACCESS% to change Strict Sit", kAv);
                             MenuForceSit(kAv,iAuth);
                         } else{
                             g_iStrictSit=1-g_iStrictSit;

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -525,6 +525,7 @@ default
         llResetScript();
     }
     state_entry(){
+        // Original: 7056 free / 5848 used out of the box
         llOwnerSay((string)llGetFreeMemory()+"/"+(string)llGetUsedMemory());
         llMessageLinked(LINK_SET, ALIVE, llGetScriptName(),"");
     }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -525,7 +525,7 @@ default
         llResetScript();
     }
     state_entry(){
-      //  llOwnerSay((string)llGetFreeMemory()+"/"+(string)llGetUsedMemory());
+        llOwnerSay((string)llGetFreeMemory()+"/"+(string)llGetUsedMemory());
         llMessageLinked(LINK_SET, ALIVE, llGetScriptName(),"");
     }
     link_message(integer iSender, integer iNum, string sStr, key kID){

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -269,14 +269,14 @@ MenuSetExceptions(key kID, integer iAuth, string sTarget){
     if(sTarget=="Owner") menutext+="OWNERS";
     else if(sTarget=="Trusted") menutext+="TRUSTED PEOPLE";
     else menutext+="'"+g_sTmpExceptionName+"'";
-    menutext+=" from being impacted by restrictions. Wearer can always:\n *IM - send them IMs\n *RcvIM - Receive their IMs\n *RcvChat - Hear their chat\n *RcvEmote - See their emotes\n *Lure - Receive their TP offers\n *StartIM - Start IM conversations with them\n *Force TP - When on, automatically accept their teleports";
+    menutext+=" from being impacted by restrictions. Wearer can always:\n *IM - send them IMs\n *RcvIM - Receive their IMs\n *RcvChat - Hear their chat\n *RcvEmote - See their emotes\n *Lure - Receive their TP offers\n *StartIM - Start IM conversations with them\n *Force TP - When on, auto-accept their TP offers";
     
     Dialog(kID, menutext, lButtons, [UPMENU], 0, iAuth, "Exceptions~Set");
 }
 
 MenuForceSit(key kID, integer iAuth) {
     
-    Dialog(kID, "\nSelect a place to force sit. Use [UNSIT] to stand up. \nSTRICT SIT prevents wearer from standing during a forced sit.\n", [Checkbox(g_iStrictSit, "Strict Sit"), UPMENU, "[UNSIT]"], [], 0, iAuth, "Restrictions~sensor");
+    Dialog(kID, "\nSelect a place to force sit. Use [UNSIT] to stand up. \nSTRICT SIT prevents wearer from standing from a forced sit except via [UNSIT].\n", [Checkbox(g_iStrictSit, "Strict Sit"), UPMENU, "[UNSIT]"], [], 0, iAuth, "Restrictions~sensor");
 }
 
 MenuCamera(key kID, integer iAuth){
@@ -545,7 +545,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                     sExceptionMasks += llList2String(lRLVEx,ix)+" = "+llList2String(lRLVEx,ix+2)+", ";
                 }
                 // list all possible bitmasks
-                llMessageLinked(LINK_SET, NOTIFY, "0Exceptions use a bitmask. Allowed values: "+sExceptionMasks+". Add selected values for the bitmask. Max bitmask is 127.", kID);
+                llMessageLinked(LINK_SET, NOTIFY, "0Exceptions use a bitmask. Allowed values: "+sExceptionMasks+". Add selected values together for the bitmask value. Max bitmask is 127.", kID);
             } else if(sChangekey == "help"){
                 // Provide a short usage summary for the console command
                 llMessageLinked(LINK_SET, NOTIFY, "0Commands: listmasks, modify, listcustom\n\nmodify takes 2-3 arguments.\nmodify owner [newBitmask]\nmodify trust [newMask]\nmodify [customExceptionName(no spaces)] [customExceptionUUID] [bitmask]", kID);
@@ -612,9 +612,9 @@ state active
         } else if(iNum == DIALOG_RESPONSE){
             // Response from a menu dialog. The menu name is stored in the
             // command UUID before the '~' character.
-            integer iPos = llSubStringIndex(kID, "~"+llGetScriptName());
-            if(iPos>0){
-                string sMenu = llGetSubString(kID,0,iPos-1);
+            integer iDelim = llSubStringIndex(kID, "~"+llGetScriptName());
+            if(iDelim>0){
+                string sMenu = llGetSubString(kID,0,iDelim-1);
                 list lMenuParams = llParseString2List(sStr, ["|"],[]);
                 key kAv = llList2Key(lMenuParams,0);
                 string sMsg = llList2String(lMenuParams,1);

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -162,19 +162,26 @@ integer samelist(list a, list b) //Returns TRUE if a and b are identical
     return !llListFindList(llListSort(a,1,1),llListSort(b,1,1));
 }
 
-string g_sMuffleReplace =
-    "p:h|P:H|t:k|T:K|m:n|M:N|o:e|O:E|u:o|U:O|w:o|W:O|b:h|B:H";
+integer g_iMuffleListener; // Listen ID for muffle chat
 
-integer g_iMuffleListener;
+string g_sMuffleReplace =
+    "phPHtkTKmnMNoeOEuoUOwoWObhBH";
 
 string MuffleText(string sText)
 {
-    list lPairs = llParseString2List(g_sMuffleReplace, ["|"], []);
+    integer len = llStringLength(g_sMuffleReplace);
     integer i;
-    for (i = 0; i < llGetListLength(lPairs); ++i)
+    for (i = 0; i < len; i += 2)
     {
-        list lPair = llParseString2List(llList2String(lPairs, i), [":"], []);
-        sText = llDumpList2String(llParseStringKeepNulls(sText, [llList2String(lPair, 0)], []), llList2String(lPair, 1));
+        string from = llGetSubString(g_sMuffleReplace, i, i);
+        string to = llGetSubString(g_sMuffleReplace, i+1, i+1);
+        integer pos = llSubStringIndex(sText, from);
+        while (pos != -1)
+        {
+            sText = llDeleteSubString(sText, pos, pos);
+            sText = llInsertString(sText, pos, to);
+            pos = llSubStringIndex(sText, from);
+        }
     }
     return sText;
 }

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -514,8 +514,7 @@ default
         llResetScript();
     }
     state_entry(){
-        // Original: 7056 free / 5848 used out of the box
-        llOwnerSay((string)llGetFreeMemory()+"/"+(string)llGetUsedMemory());
+        //llOwnerSay((string)llGetFreeMemory()+"/"+(string)llGetUsedMemory());
         llMessageLinked(LINK_SET, ALIVE, llGetScriptName(),"");
     }
     link_message(integer iSender, integer iNum, string sStr, key kID){


### PR DESCRIPTION
I want to add new functionality to oc_rlvextension.ls in a subsequent commit. Since that would be built on top of this, this is a separate PR to reduce script memory usage with no functional changes.

- Muffle code refactored
- Some strings shortened
- Removed redundant llParseString2List calls in UserCommand
 
Startup memory shows a reduction of ~1,982 bytes