### PR TITLE
oc_anim add groundsit function

### DIFF
--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -289,7 +289,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                     
                 }
             }else llMessageLinked(LINK_SET, NOTIFY, "0%NOACCESS% to changing pose offset", kID);
-        } else if( sChangetype=="groundsit" || sChangeType=="park") {
+        } else if( sChangetype=="groundsit" || sChangetype=="park") {
                 if(sChangevalue=="on" && g_iGroundSit==FALSE)
                 {
                     llOwnerSay("@sitground=force");
@@ -841,6 +841,7 @@ state inUpdate{
         }
     }
 }
+
 
 
 

--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -30,6 +30,7 @@ Medea (Medea Destiny)
                 
     Jan 2025    - Added groundsit button. Triggers ground sit and locks standing. Must have same or
                 higher auth to undo.
+    Nov 2025   -  Added CMD_INFO handling for UNSIT to manage ground sits.
 
 Nikki Larima 
     May 2025    - CMD_SAFEWORD handler to remove animlock and stop all animations
@@ -54,7 +55,7 @@ integer CMD_EVERYONE = 504;
 //integer CMD_RLV_RELAY = 507;
 integer CMD_SAFEWORD = 510;
 //integer CMD_RELAY_SAFEWORD = 511;
-
+//integer CMD_INFO = 555;
 integer NOTIFY = 1002;
 integer REBOOT = -1000;
 
@@ -676,7 +677,8 @@ state active
                     if(iRespring)PoseMenu(kAv,iAuth, iPage);
                 }
             }
-            
+        } else if(iNum==555) { //CMD_INFO
+            if(llGetSubString(sMsg,0,4)=="unsit") UserCommand((integer)llGetSubString(sMsg,6,-1),"groundsit off",kAv);
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
@@ -839,3 +841,4 @@ state inUpdate{
         }
     }
 }
+

--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -31,7 +31,7 @@ Medea (Medea Destiny)
     Jan 2025    - Added groundsit button. Triggers ground sit and locks standing. Must have same or
                 higher auth to undo.
     Nov 2025   -  Added CMD_INFO handling for UNSIT to manage ground sits.
-
+    Dec 2025   - Changed "groundsit" to "park"
 Nikki Larima 
     May 2025    - CMD_SAFEWORD handler to remove animlock and stop all animations
 
@@ -134,7 +134,7 @@ integer g_iPosture = FALSE;
 integer g_iStandOffset = FALSE;
 Menu(key kID, integer iAuth) {
     string sPrompt = "\n[Animations]\n\nCurrent Animation: "+setor((g_lCurrentAnimations==[]), "None", llList2String(g_lCurrentAnimations, 0)+"\nCurrent Pose: "+setor((g_sPose==""), "None", g_sPose));
-    list lButtons = [Checkbox(g_iGroundSit, "Ground Sit"),Checkbox(g_iAnimLock,"AnimLock"), "Pose"];
+    list lButtons = [Checkbox(g_iGroundSit, "Park"),Checkbox(g_iAnimLock,"AnimLock"), "Pose"];
     
     if(llGetInventoryType("~stiff")==INVENTORY_ANIMATION){
         lButtons += [Checkbox(g_iPosture, "Posture")];
@@ -289,7 +289,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                     
                 }
             }else llMessageLinked(LINK_SET, NOTIFY, "0%NOACCESS% to changing pose offset", kID);
-        } else if( sChangetype=="groundsit") {
+        } else if( sChangetype=="groundsit" || sChangeType=="park") {
                 if(sChangevalue=="on" && g_iGroundSit==FALSE)
                 {
                     llOwnerSay("@sitground=force");
@@ -650,7 +650,7 @@ state active
                             }
                         }
                     } 
-                    else if(sMsg == Checkbox(g_iGroundSit,"Ground Sit"))
+                    else if(sMsg == Checkbox(g_iGroundSit,"Park"))
                     { 
                         if(g_iGroundSit) UserCommand(iAuth,"groundsit off",kAv);
                         else UserCommand(iAuth,"groundsit on",kAv);
@@ -841,5 +841,6 @@ state inUpdate{
         }
     }
 }
+
 
 

--- a/src/collar/oc_anim.lsl
+++ b/src/collar/oc_anim.lsl
@@ -678,7 +678,7 @@ state active
                 }
             }
         } else if(iNum==555) { //CMD_INFO
-            if(llGetSubString(sMsg,0,4)=="unsit") UserCommand((integer)llGetSubString(sMsg,6,-1),"groundsit off",kAv);
+            if(llGetSubString(sStr,0,4)=="unsit") UserCommand((integer)llGetSubString(sStr,6,-1),"groundsit off",kID);
         } else if (iNum == DIALOG_TIMEOUT) {
             integer iMenuIndex = llListFindList(g_lMenuIDs, [kID]);
             g_lMenuIDs = llDeleteSubList(g_lMenuIDs, iMenuIndex - 1, iMenuIndex +3);  //remove stride from g_lMenuIDs
@@ -841,4 +841,5 @@ state inUpdate{
         }
     }
 }
+
 

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -55,6 +55,7 @@ Medea Destiny -
                     memory load, this one's already very tight. Issue #1008
                 -   folded bool() function into checkbox() function with (iValue&1) and strReplace() into
                     MuffleText() to save memory
+    Nov 2025    -   Added informational LM to indicate UNSIT sent via CMD_INFO (555)
 
 Krysten Minx -
     May 2022    -   Added check for valid UUID when setting custom exception
@@ -85,7 +86,7 @@ integer CMD_EVERYONE = 504;
 //integer CMD_RLV_RELAY = 507;
 //integer CMD_SAFEWORD = 510;
 //integer CMD_RELAY_SAFEWORD = 511;
-
+//integer CMD_INFO=555;
 integer NOTIFY = 1002;
 
 // Link message constants used for communication with other scripts.
@@ -499,6 +500,7 @@ UserCommand(integer iNum, string sStr, key kID) {
                 llSleep(1.5);
                 if(iNum==CMD_OWNER) llMessageLinked(LINK_SET,RLV_CMD_OVERRIDE,"unsit~unsit",kID);
                 else llMessageLinked(LINK_SET,RLV_CMD,"unsit=force","Macros");
+                llMessageLinked(LINK_SET,555,"unsit|"+(string)iNum,kID); //555=CMD_INFO
                 g_iLastSitAuth = 599;
             } else {
                 if(iNum > g_iLastSitAuth){


### PR DESCRIPTION
New button triggers groundsit. This is a "parking" type feature which will sit the wearer on the ground with standard groundsit animation (from AO) and lock standing. Same or higher auth as the person issuing the command is required to undo and allow moving again.