### PR TITLE
Leash fix number 4183945

### DIFF
--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -41,6 +41,8 @@ Medea (medea.destiny)
                 get sensor menu
                 - Added Strict(ish) mode that doesn't include fartouch restriction. Refactored code
                 to avoid menu desync & reduce redundancy
+                - Set g_iAwayCounter when dropping leash due to line of sight in case leasher leaves
+                sim while in this state, causing strict mode restrictions to drop
 Nikki Larima 
     Nov 2023    - Remove processing of "runaway" command string, handled by CMD_SATEWORD
                   implemented Yosty7b3's menu streamlining, see pr#963    
@@ -1124,6 +1126,7 @@ state active
                     g_iVelCount=0;
                     llTargetRemove(g_iTargetHandle);
                     llMessageLinked(LINK_THIS,NOTIFY,"1Leash movement blocked, unleashing until back in line of sight",g_kLeashedTo);
+                    g_iAwayCounter=llGetUnixTime()+180; //in case leasher leaves sim, set a 3 minute timer before dropping restictions.
                     g_iLeasherInRange=FALSE;
                     return;
                 }

--- a/src/collar/oc_leash.lsl
+++ b/src/collar/oc_leash.lsl
@@ -43,6 +43,7 @@ Medea (medea.destiny)
                 to avoid menu desync & reduce redundancy
                 - Set g_iAwayCounter when dropping leash due to line of sight in case leasher leaves
                 sim while in this state, causing strict mode restrictions to drop
+   Jan 2026    - fix for face menu backbutton not working
 Nikki Larima 
     Nov 2023    - Remove processing of "runaway" command string, handled by CMD_SATEWORD
                   implemented Yosty7b3's menu streamlining, see pr#963    
@@ -634,6 +635,11 @@ UserCommand(integer iAuth, string sMessage, key kMessageID, integer bFromMenu) {
             }
         }else if (sComm=="face") 
         {
+            if (sVal==llToLower(BUTTON_UPMENU))
+            {
+                UserCommand(iAuth, "leashmenu", kMessageID ,bFromMenu);
+                return;
+            }
             if(sVal=="me") sVal=(string)kMessageID;
             vector vTargPos=llList2Vector(llGetObjectDetails((key)sVal,[OBJECT_POS]),0);
             if(vTargPos==ZERO_VECTOR) 


### PR DESCRIPTION
Clover spotted a situation with the line-of-sight thing in long term testing where strict mode restrictions were being dropped instantly if the leashee leaves range while the collar is in the state where waiting for line of sight to be restored. 

This change set g_iAwayCounter to manage  to trigger the countdown when line-of-sight is dropped, which should fix the issue. Initial reports are good but let's see how this behaviour pans out in testing.