### PR TITLE
Update handling of RLVA_VERSION in oc_outfits.lsl

### DIFF
--- a/src/Apps/oc_outfits.lsl
+++ b/src/Apps/oc_outfits.lsl
@@ -399,9 +399,10 @@ state active
     link_message(integer iSender,integer iNum,string sStr,key kID){
         if(iNum >= CMD_OWNER && iNum <= CMD_EVERYONE) UserCommand(iNum, sStr, kID);
         else if(iNum == RLVA_VERSION ){
-               if(sStr != "0"){
-                  g_iRLVa=TRUE;
-               }else g_iRLVa=FALSE;
+            if(sStr != "0"){
+                g_iRLVa=TRUE;
+            } else g_iRLVa=FALSE;
+            Process();
         }
         else if(iNum == MENUNAME_REQUEST && sStr == g_sParentMenu)
             llMessageLinked(iSender, MENUNAME_RESPONSE, g_sParentMenu+"|"+ g_sSubMenu,"");


### PR DESCRIPTION
Call Process() when receiving link message RLVA_VERSION to enable core lock with rlva folder naming conventions.

**The long writeup**:
With Outfits / Lock Core setting in oc_outfits, the .core folder does not lock on startup.  A cycle of unlock/lock is needed ! Ref #1210.

**Mechanism.**
Changing g_iLockCore calls Commit()  and Commit calls Process() that sets the RLV lock using GetOutfitSystem(TRUE). GetOutfitSystem uses g_iRLVa flag to select the path “.outfits/.core”

Reading LM_SETTING_RESPONSE outfits_lockcore calls Process() as it should. 

LinkMessage iNum == RLVA_VERSION sets g_iRLVa flag but _does not call Process()_.

So for this to work  iNum == RLVA_VERSION must occur before LM_SETTING_RESPONSE outfits_lockcore, but after switching to state active.
This is a race condition between the initialization of RLV and the sending of LM_SETTING_RESPONSE outfits_lockcore that it seems has usually worked in pre 8.4

**The problem.**
OC 8.4 sends RLVA_VERSION twice, first when RLV_ON is confirmed, and this has moved to be early, before iNum == STARTUP triggers the state switching. Second is after LM_SETTING_RESPONSE settings=sent and this is after LM_SETTING_RESPONSE outfits_lockcore so Process() is not called with the correct outfit system path (unless g_iLockCore is toggled off/on).

Fix
Several possible ways to fix this.

1. Make oc_outfits listen for iNum == RLVA_VERSION in default state. Will work as long as RLV system is active before LM_SETTING_RESPONSE outfits_lockcore.

2. Make LinkMessage iNum == RLVA_VERSION call Process(). This will be done a bit after LM_SETTING_RESPONSE settings=sent
 
3. Make oc_rlvsys send the  LinkMessage iNum == RLVA_VERSION in response to iNum == STARTUP

This patch implements the second method. 