### PR TITLE
Update Makefile for lslint v1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 	endif
 endif
 
-LSLINT_VERSION := v1.0.8
+LSLINT_VERSION := v1.3
 LSLINT_FILE := lslint_$(LSLINT_VERSION)_$(LSLINT_ENV).zip
 LSLINT_URL := https://github.com/Makopo/lslint/releases/download/$(LSLINT_VERSION)/$(LSLINT_FILE)
 LSLINT := bin/lslint


### PR DESCRIPTION
The v1.0.8 release of lslint is a binary of type  `Mach-O executable i386`
which means it does not runs on a 64bit macOS, especially on 32bit Intel CPU. Apple moved to "64bit-only" with the release of macOS Catalina  in 2019. Later in 2020 Apple move to the Apple Silicon M CPUs, with M1 being introduced in 2020.

So basically lslint version v1.0.8 does not longer work on macOS development hardware since 2020.

Latest official release is v1.3 ( https://github.com/Makopo/lslint/releases#release-v1.3 ), which is of type `Mach-O 64-bit executable x86_64` which at least is executable on a Apple M2 CPU via the Apple Rosetta2 x86_64-on-Silicon emulation.

Nevertheless, this needs to be testet for compatibility especially on Linux/Win dev systems !
One might want at least to delete the bin/lslint and execute make:

>    $ rm -rf bin
>    $ make
>    mkdir -p bin
>    cd bin; curl -L https://github.com/Makopo/lslint/releases/download/v1.3/lslint_v1.3_osx.zip -o lslint_v1.3_osx.zip
>    cd bin; unzip lslint_v1.3_osx.zip
>    Archive:  lslint_v1.3_osx.zip
>      inflating: lslint
>    $ bin/lslint --version
>    lslint v1.3
